### PR TITLE
fix(terraform): remove duplicate Foundry app outputs (#14)

### DIFF
--- a/infrastructure/modules/foundry-app/outputs.tf
+++ b/infrastructure/modules/foundry-app/outputs.tf
@@ -4,40 +4,12 @@
 
 output "user_data" {
   description = "Base64-encoded cloud-init user-data for Foundry provisioning"
-  value = base64encode(templatefile("${path.module}/templates/cloud-init.yaml", {
-    foundry_hostname        = var.foundry_hostname
-    data_mount_path         = var.data_mount_path
-    data_device             = var.data_device
-    data_volume_fs_label    = var.data_volume_fs_label
-    foundry_image           = var.foundry_image
-    cloudflared_image       = var.cloudflared_image
-    timezone                = var.timezone != "" ? var.timezone : "UTC"
-    foundry_username        = var.foundry_username
-    foundry_password        = var.foundry_password
-    foundry_release_url     = var.foundry_release_url
-    foundry_license_key     = var.foundry_license_key
-    foundry_admin_key       = var.foundry_admin_key
-    cloudflare_tunnel_token = var.cloudflare_tunnel_token
-  }))
-  sensitive = true
+  value       = base64encode(local.cloud_init_template)
+  sensitive   = true
 }
 
 output "user_data_raw" {
   description = "Unencoded cloud-init user-data (for debugging)"
-  value = templatefile("${path.module}/templates/cloud-init.yaml", {
-    foundry_hostname        = var.foundry_hostname
-    data_mount_path         = var.data_mount_path
-    data_device             = var.data_device
-    data_volume_fs_label    = var.data_volume_fs_label
-    foundry_image           = var.foundry_image
-    cloudflared_image       = var.cloudflared_image
-    timezone                = var.timezone != "" ? var.timezone : "UTC"
-    foundry_username        = var.foundry_username
-    foundry_password        = var.foundry_password
-    foundry_release_url     = var.foundry_release_url
-    foundry_license_key     = var.foundry_license_key
-    foundry_admin_key       = var.foundry_admin_key
-    cloudflare_tunnel_token = var.cloudflare_tunnel_token
-  })
-  sensitive = true
+  value       = local.cloud_init_template
+  sensitive   = true
 }


### PR DESCRIPTION
## Summary

- keep `user_data` and `user_data_raw` declared once in `outputs.tf`
- render cloud-init once through `local.cloud_init_template`
- preserve the existing contract: `user_data` is base64 encoded and `user_data_raw` is unencoded
- leave all provider consumers unchanged, including issue #18 behavior

## Root cause

The module already had a shared `local.cloud_init_template`, but each output repeated the full `templatefile` expression. This left multiple implementations of the same rendered payload and made the intended single authoritative output path unclear.

## Validation

- `terraform fmt -check infrastructure/modules/foundry-app/main.tf infrastructure/modules/foundry-app/outputs.tf` — pass
- output declaration count — exactly one `user_data` and one `user_data_raw`
- `terraform init -backend=false -input=false && terraform validate` in `infrastructure/modules/foundry-app` — pass
- Hetzner consuming deployment initialization — pass
- Hetzner consuming deployment validation — blocked by the pre-existing unsupported `automount` argument at `infrastructure/modules/providers/hetzner/main.tf:77`
- `git diff --check` — pass
- pre-push Semgrep and TruffleHog gates — pass

Closes #14
