### PR TITLE
Bump grouped GitHub Actions dependencies

### DIFF
--- a/.github/workflows/quality-security.yml
+++ b/.github/workflows/quality-security.yml
@@ -19,7 +19,7 @@ jobs:
 
     steps:
       - name: Checkout
-        uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
         with:
           fetch-depth: 0
 
@@ -29,7 +29,7 @@ jobs:
           extra_args: --results=verified,unknown
 
       - name: Setup Python
-        uses: actions/setup-python@ece7cb06caefa5fff74198d8649806c4678c61a1 # v6.3.0
+        uses: actions/setup-python@5fda3b95a4ea91299a34e894583c3862153e4b97 # v7.0.0
         with:
           python-version: "3.12"
 

--- a/.github/workflows/semgrep.yml
+++ b/.github/workflows/semgrep.yml
@@ -32,7 +32,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       # Checkout project source
-      - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
 
       # Scan code using project's configuration on https://semgrep.dev/manage
       - uses: returntocorp/semgrep-action@713efdd345f3035192eaa63f56867b88e63e4e5d
@@ -43,7 +43,7 @@ jobs:
 
       # Upload SARIF file generated in previous step
       - name: Upload SARIF file
-        uses: github/codeql-action/upload-sarif@99df26d4f13ea111d4ec1a7dddef6063f76b97e9 # v4.37.0
+        uses: github/codeql-action/upload-sarif@e4fba868fa4b1b91e1fdab776edc8cfbe6e9fb81 # v4.37.3
         with:
           sarif_file: semgrep.sarif
         if: always()


### PR DESCRIPTION
## Summary

- apply the grouped updates found by the local Dependabot GitHub Actions discovery job
- bump actions/checkout from 7.0.0 to 7.0.1
- bump actions/setup-python from 6.3.0 to 7.0.0
- bump github/codeql-action/upload-sarif from 4.37.0 to 4.37.3
- keep every action pinned to an immutable commit SHA

## Validation

- pre-commit run --all-files --hook-stage pre-commit
- pre-commit run --all-files --hook-stage pre-push
- TERRAFORM_QUALITY_TARGETS=aws,azure,gcp,hetzner scripts/terraform-quality.sh
- git diff --check

Dependency gate for issue #47; this PR remains isolated from the issue-closure changes.