### PR TITLE
build(deps): bump GCP providers to 7.41.0

### DIFF
--- a/infrastructure/deployments/gcp/.terraform.lock.hcl
+++ b/infrastructure/deployments/gcp/.terraform.lock.hcl
@@ -2,44 +2,44 @@
 # Manual edits may be lost in future updates.
 
 provider "registry.terraform.io/hashicorp/google" {
-  version     = "7.40.0"
+  version     = "7.41.0"
   constraints = "~> 7.39"
   hashes = [
-    "h1:ALcfR9PrN49rz4bO/KkLKfGlOmbKejdzmAl+frMhba8=",
-    "h1:AlekfK/kVz+q+zGzJnMgMu0HwyNE4ZYecspHfZ1xAr0=",
-    "zh:0e905b46ee345a95797ea0ed2e76210c9a3410a253f5b87beee1f793f0be1bb7",
-    "zh:5733ab3bb2b8ad78afa6d0c60c31253ef90eefbf342c361be79f87857290a2f9",
-    "zh:57d4e829208aa1ba70719d706bfe4e43a4d429ffc30d5273335a9f0d39868b32",
-    "zh:5eeb315b099f5deaa9c20c93f5ed510124fedbd95d728075aec1a3be2bf48e84",
-    "zh:73be6c47ffed660a0964ab3a3d260aece3ab307fe580693f4440afff0cebe850",
-    "zh:87753d2297a4901bb58c5dbbf9a021439996afc16a331033aa23e707e5a82564",
-    "zh:93f95e5257375a3a13ac7214292106b9557c312e59a31b6adaa025ec3eb27506",
-    "zh:afb1bcd569b90ca23cfb0e916e4fa50627ba2fb33381151490b4e2be8b782289",
-    "zh:b4d16b7cac1b222deeffc24e8ed7a476afe45113e793f32eac7189a819fbd17f",
-    "zh:bfc545c4ad85d057bed651d5a63bda18666322b27b9423430adf2f6847fa62f8",
+    "h1:+wur8ZrXd5n6e4qXbiSRq9GntW/gmZ7rsWsvJPo3bB4=",
+    "h1:j7CeM9SQQvTWReE3vajyOaNrjsp72dbGVRnFjuk6LPA=",
+    "zh:162ba4a321308dc683f13faaf8d0ec98efda9245f0a07d5abb867da5963d00b2",
+    "zh:2377a2db9b5a6977fe16f75b107bc47e663630b5a7a8e7a99006cdd820e70ed7",
+    "zh:24cd310110d08d4e5c74c78da41c4f95573c39e4eaef2c92650ebb71cb91e9a1",
+    "zh:3315101a286b57ed6a742a8c7c04809f9ef79da3bfa6df5847bbaff207e80d31",
+    "zh:50f193d70277c5a8c6d8736ac2f4bf4f390b0a265e8d0044c7cb30fbef1f2ee8",
+    "zh:5a32a8565ff7084bff87ccd56e26cb31b78c98625a94fd49ec78b48f27f1ced6",
+    "zh:5ec0abe1056adb1f84dc4645583e1ca92b891d694929d849f82cee7221f72bfb",
+    "zh:99fa3a8a1d42cace4df576b1111fe2a9286c8a40e6c7fab778f13213c9fe858a",
+    "zh:b715f6779d201c80e8f83a21acd43f474da13dd329721cec6cd4450c42398c5e",
+    "zh:cc1f3acaaf68f4ff19ef5893e9cefca63e5b93c0800517dfc0a60672911c3f26",
     "zh:f569b65999264a9416862bca5cd2a6177d94ccb0424f3a4ef424428912b9cb3c",
-    "zh:fceb8f992ab00dbf8ab5e78f2033973d9c1562c55ec223f46babc2f0a7ecc3db",
+    "zh:fd3a26b4d131414045af53780aae841e930ec6af432794768549760c7d364765",
   ]
 }
 
 provider "registry.terraform.io/hashicorp/google-beta" {
-  version     = "7.40.0"
+  version     = "7.41.0"
   constraints = "~> 7.39"
   hashes = [
-    "h1:+L0dwuuFCyZUVb+0VMvFCBFwf6Lc+vsP0y8lP6ofP9c=",
-    "h1:o7TK9dRZADXVHTJhLZjSV1gnY4H0EngWCyf7ae7t/Xg=",
-    "zh:3946350745941274a43e561d351fa4a051929883ad7bb52230c59f0e8b44e302",
-    "zh:3befd2d7210a1224563abd0d6b1d0cae14710f078b98fc81f7eb370ee9ddff3e",
-    "zh:846da1ca7b81b32ea5c70b0ca388212ef12fd6f6d73b7e7ce98c5d2c1d033f7b",
-    "zh:970646fe1568ad35826f929826536be51bc547a8e59a335b4202860670fe9938",
-    "zh:99e29f3778a1a10ee7687fcd55dcc151a0ff62b23281c19b7e2f2cda5c10556d",
-    "zh:9cbf88359119afdd7c4bbe5fc02cc43e635a8a34a3b474e66e89cef26592542c",
-    "zh:a41da7c4d69f418f93f12529a630c2af9870f917959b0a2018e7f12ab848b7f6",
-    "zh:df1bad58418a7380a99bbfb09fbfe18120af2d7667547149cd4f65713e232330",
-    "zh:e48c1d7db3e4b3d7585a212a8cbc4e9f8853844f3d6262f98993c164ddd9249d",
+    "h1:dYpfNOwDM08iYP6TyxArQzxUOyKGDPco4MdKF1v5Fu0=",
+    "h1:nMuVkZ0uuVcSoN+y8d8vGaxAUwTEE9Rnts2RYN8BOJk=",
+    "zh:02818011b780f0479c85cae2451019ac7856b019f73d91b1fbec6e43b5a17eb8",
+    "zh:3327114343f64b81f7210effed99b39ec6e227eb3815c4da1ead272939fbab57",
+    "zh:371eb1484eeccbdd51ef1e15df5db34003313f6f56125dd47fc3e644db7519f8",
+    "zh:4d7594e8b0c3f3ca9ac279bd6046769abf04569a29e0f37b7bd80e2a8b22c90b",
+    "zh:704eeb9c7374ef581d323e3105b497439e5824c4d2d09c877b8b3c9d11dfad10",
+    "zh:7f20de56cad83e2e9924789f191dd0763d4b667aeb658e2ec1922947ae26d2e9",
+    "zh:98945ef3033fcbbad8be7787c190d1cbe39e8645945fb045827fe71b1052f094",
+    "zh:ab97cbba92837c55513f400cf5fbeb70bc5f5d602d60e9c7f341ce38e3047fad",
+    "zh:d8a727ddaf884df596b0f7af8fcf3a73a445084e21a0c8918c5f43f8b54fd66b",
+    "zh:e8406fd7380ef15cc53ae0874236909ed57bb743f02a11baca9bb61467bc0cb4",
+    "zh:ee681e601431fb40aad48a0dd8709bca9aeb654a62ae1c85a072bd406d62085a",
     "zh:f569b65999264a9416862bca5cd2a6177d94ccb0424f3a4ef424428912b9cb3c",
-    "zh:fc84ba75a392bd404607ce1760cb9b3bae0632505976e1d3c2cf98217a9bb881",
-    "zh:ff93e1841b6b3876c95ee40a4e3889a0efb4347a24067f53c18ffaa0503de4f0",
   ]
 }
 


### PR DESCRIPTION
## Summary

- bump `hashicorp/google` from 7.40.0 to 7.41.0
- bump `hashicorp/google-beta` from 7.40.0 to 7.41.0
- preserve the existing `~> 7.39` constraints and `hashicorp/random` lock entry
- update only the GCP deployment lockfile

## Why

A local Dependabot discovery job against base commit `719cf6bafbf5d917ad275401693e0b3b878539df` found both GCP provider patch updates. This PR keeps those dependency changes isolated from issue #47's closure implementation.

The two provider blocks exactly match the independently generated Dependabot lockfile results in the local audit artifact.

## Impact

GCP Terraform initialization now resolves the Google and Google Beta providers at 7.41.0. No Terraform configuration, version constraint, infrastructure behavior, or other cloud deployment is changed.

## Validation

- exact Dependabot `hashicorp/google` and `hashicorp/google-beta` lockfile blocks verified after validation
- `pre-commit run --all-files --hook-stage pre-commit`
- `TERRAFORM_QUALITY_TARGETS=aws,azure,gcp,hetzner scripts/terraform-quality.sh`
- `pre-commit run --all-files --hook-stage pre-push`
- `git diff --check`
- push-time Semgrep: 0 findings
- push-time TruffleHog: 0 verified or unverified secrets

All checks passed. Terraform validation emitted only the repository's existing provider deprecation warnings in AWS, Azure, and GCP.
