### PR TITLE
Bump TruffleHog action to 3.96.0

### DIFF
--- a/.github/workflows/quality-security.yml
+++ b/.github/workflows/quality-security.yml
@@ -24,7 +24,7 @@ jobs:
           fetch-depth: 0
 
       - name: Scan commits for secrets
-        uses: trufflesecurity/trufflehog@27b0417c16317ca9a472a9a8092acce143b49c55 # v3.95.9
+        uses: trufflesecurity/trufflehog@6f3c981e7b77f235fd2702dd74af25fc4b72bf11 # v3.96.0
         with:
           extra_args: --results=verified,unknown
 


### PR DESCRIPTION
## Summary

- update `trufflesecurity/trufflehog` from 3.95.9 to 3.96.0
- preserve immutable SHA pinning

## Validation

- pre-commit stage: passed
- pre-push stage: passed
- Terraform quality: AWS, Azure, GCP, and Hetzner passed
- diff check: passed

Dependency gate for issue #47.
