### PR TITLE
Close Hetzner backup and lifecycle documentation gaps

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -23,6 +23,13 @@ repos:
         language: system
         stages: [pre-commit]
 
+      - id: issue-47-acceptance-tests
+        name: Hetzner backup restore and documentation tests
+        entry: python3 -m unittest discover -s tests -p "test_*.py"
+        language: system
+        pass_filenames: false
+        stages: [pre-commit]
+
       - id: semgrep
         name: semgrep scan
         entry: bash scripts/semgrep-scan.sh

--- a/DOCUMENTATION_INDEX.md
+++ b/DOCUMENTATION_INDEX.md
@@ -44,6 +44,9 @@ This index is the navigation hub for LegendForge documentation. It highlights th
   - Contains Azure deployment guidance
   - Complements the LegendForge core docs with provider-specific details
 
+- **[Deployment model comparison](docs/DEPLOYMENT_MODEL_COMPARISON.md)** - Terraform-grounded provider profiles, cost drivers, and operational trade-offs
+- **[Hetzner deployment guide](infrastructure/deployments/hetzner/README.md)** - Single-server topology, security, tested off-server archive workflow, recovery, and destructive lifecycle limits
+
 ### GitHub Wiki Source Pages
 - **[wiki/Home.md](wiki/Home.md)** - Wiki landing page and overview
 - **[wiki/Quickstart.md](wiki/Quickstart.md)** - Shortest path to a first deployment
@@ -65,7 +68,7 @@ This index is the navigation hub for LegendForge documentation. It highlights th
 
 ### For Deployment Operators
 1. Start with **[README.md](README.md)**
-2. Use the relevant provider guide in `deployments/*/README.md`
+2. Use the relevant provider guide in `infrastructure/deployments/*/README.md`
 3. Review **[ATTRIBUTION.md](ATTRIBUTION.md)** for dependency and license context
 
 ### For Contributors and Reviewers
@@ -114,10 +117,11 @@ This index is the navigation hub for LegendForge documentation. It highlights th
 - `CREDITS.md`
 
 ### Provider-Specific Guidance
-- `deployments/aws/README.md`
-- `deployments/azure/README.md`
-- `deployments/gcp/README.md`
-- `deployments/hetzner/README.md`
+- `infrastructure/deployments/aws/README.md`
+- `infrastructure/deployments/azure/README.md`
+- `infrastructure/deployments/gcp/README.md`
+- `infrastructure/deployments/hetzner/README.md`
+- `docs/DEPLOYMENT_MODEL_COMPARISON.md`
 - `README_AZURE.md`
 
 ### GitHub Wiki Pages
@@ -135,7 +139,7 @@ This index is the navigation hub for LegendForge documentation. It highlights th
 ## 📝 Attribution in Infrastructure
 
 ### Deployment Entry Points
-The deployment entry points under `deployments/*/main.tf` should continue to reflect upstream dependencies and provider assumptions where appropriate.
+The deployment entry points under `infrastructure/deployments/*/main.tf` should continue to reflect upstream dependencies and provider assumptions where appropriate.
 
 ### Shared App Layer
 The `modules/foundry-app/` area is the clearest expression of the project's system-agnostic design. When this layer changes, update the core docs first.
@@ -152,7 +156,7 @@ The `modules/foundry-app/` area is the clearest expression of the project's syst
 ### If You Are Planning a New Deployment
 - Use **README.md** for setup flow
 - Review **SUPPORTED_SYSTEMS.md** for system-family guidance
-- Follow the provider-specific README in `deployments/`
+- Follow the provider-specific README in `infrastructure/deployments/`
 - Use the pages under **`wiki/`** when you want GitHub wiki-ready navigation
 
 ### If You Are Reviewing Compliance or Upstream Dependencies
@@ -198,6 +202,6 @@ Please open an issue or submit a pull request.
 
 ---
 
-**Last Updated:** June 28, 2026
+**Last Updated:** July 23, 2026
 
 **LegendForge Positioning:** Universal tabletop infrastructure for Foundry-compatible systems

--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 
 ![LegendForge Logo](resources/LegendForge_Logo.png)
 
-LegendForge is a universal, production-ready **Terraform infrastructure platform** for deploying Foundry VTT across multiple cloud providers with security-first defaults, automatic backups, and support for many tabletop game systems.
+LegendForge is a universal, production-minded **Terraform infrastructure platform** for deploying Foundry VTT across multiple cloud providers with security-first defaults, provider-specific recovery controls, and support for many tabletop game systems.
 
 ## 📋 Overview
 
@@ -39,7 +39,7 @@ LegendForge is built for campaigns and communities running multiple systems side
 LegendForge treats Foundry as **universal tabletop infrastructure**:
 
 - Infrastructure should be **agnostic to rulesets and genres**
-- Security, backups, and observability should work the same way for every campaign
+- Security, backups, and observability should meet each campaign's requirements even when provider implementations differ
 - Cloud architecture should be **portable across providers**
 - Documentation should help operators run one world or many worlds with confidence
 - The platform should scale from a home game to a multi-campaign community
@@ -53,7 +53,7 @@ LegendForge treats Foundry as **universal tabletop infrastructure**:
 - ✅ **Tunnel-First Security**: Cloudflare Tunnel for ingress (no exposed ports)
 - ✅ **IaC Everything**: Fully declarative, version-controlled infrastructure
 - ✅ **Multi-Cloud**: Deploy to any platform with the same operational model
-- ✅ **High Availability**: Automated backups, monitoring, alerting
+- ✅ **Provider-Specific Resilience**: Documented availability, backup, monitoring, and recovery trade-offs
 - ✅ **Secrets Management**: Cloud-native secret storage (Vault, Key Vault, Secret Manager)
 - ✅ **Cost Optimized**: Right-sized instances, easy spin-down
 - ✅ **Comprehensive Documentation**: Step-by-step guides for each platform and operating model
@@ -296,23 +296,20 @@ gcloud compute disks snapshot disk-name --snapshot-names=backup-$(date +%Y%m%d%H
 
 **Hetzner:**
 
-```bash
-hcloud volume create-backup <volume-id>
-```
+Use the tested application-data archive procedure in the
+[Hetzner deployment guide](infrastructure/deployments/hetzner/README.md#backup-and-recovery).
+The repository does not provision scheduled Hetzner backups, and a provider-side
+copy does not replace an encrypted off-server archive.
 
-### Pause Deployment (Keep Data)
+### Pause or Scale Down a Deployment
 
-All platforms support spin-down via variable:
+Inspect the provider-specific Terraform plan and guide before disabling compute.
+The persistence behavior is not uniform across providers.
 
-```bash
-terraform apply -var="compute_enabled=false"   -var-file="../../../config/foundry.auto.tfvars"   -var-file="../../../config/secrets.auto.tfvars"
-```
-
-### Resume Deployment
-
-```bash
-terraform apply -var="compute_enabled=true"   -var-file="../../../config/foundry.auto.tfvars"   -var-file="../../../config/secrets.auto.tfvars"
-```
+For Hetzner, `compute_enabled=false` deletes both the server and the
+Terraform-managed data volume. It is not a data-preserving pause. Follow the
+[Hetzner lifecycle guidance](infrastructure/deployments/hetzner/README.md#pause-and-resume)
+and verify an off-server backup before any teardown-like action.
 
 ### Destroy Infrastructure
 
@@ -320,7 +317,8 @@ terraform apply -var="compute_enabled=true"   -var-file="../../../config/foundry
 terraform destroy   -var-file="../../../config/foundry.auto.tfvars"   -var-file="../../../config/secrets.auto.tfvars"
 ```
 
-⚠️ **WARNING:** This deletes data volumes. Create snapshots first if needed.
+⚠️ **WARNING:** Destroy can delete data volumes. Verify a tested, independent
+backup before continuing.
 
 ## 🔐 Security Best Practices
 
@@ -445,12 +443,17 @@ docker exec foundry env | grep TUNNEL
 
 ### Regular Backups
 
-All platforms have automated backup schedules:
+Backup automation and recovery ownership vary by provider:
 
-- AWS: Daily snapshots via AWS Backup
-- Azure: Daily snapshots via Backup Vault
-- GCP: Daily snapshots via Disk Resource Policy
-- Hetzner: Manual backups (create via console)
+- AWS: RDS automated-backup retention and versioned S3 data buckets; the active
+  deployment does not schedule application-volume snapshots
+- Azure: database backup-retention/geo-redundancy controls and a VM backup
+  policy through the active Recovery Services Vault module
+- GCP: Cloud SQL automated backups and versioned Cloud Storage data/backup
+  buckets; the active deployment does not attach a disk snapshot policy
+- Hetzner: Operator-managed application archive, off-server transfer, checksum
+  verification, and restore drills; see the
+  [Hetzner deployment guide](infrastructure/deployments/hetzner/README.md#backup-and-recovery)
 
 ### Disk Usage Monitoring
 
@@ -604,12 +607,15 @@ A: See the overview table above. AWS/Azure are roughly $50-75, GCP is roughly $4
 A: Change the `foundry_image` digest in config and re-apply Terraform.
 
 **Q: Can I use this for production?**
-A: Yes. All platforms include backups, monitoring, and security best practices. Follow cloud provider HA guidance for enterprise-style environments.
+A: Yes, after reviewing the selected provider's availability and recovery model.
+AWS, Azure, and GCP include more managed controls; Hetzner is a single-server
+deployment whose backups, restore drills, monitoring, and maintenance are
+operator responsibilities.
 
 **Q: How do I access Foundry if Cloudflare is down?**
 A: Cloudflare Tunnel is the primary ingress path. For break-glass operations, enable an administrative access path such as SSH or Bastion according to your provider model.
 
 ---
 
-**Last Updated:** June 28, 2026
+**Last Updated:** July 23, 2026
 **Project Identity:** LegendForge - universal tabletop infrastructure for Foundry VTT

--- a/docs/DEPLOYMENT_MODEL_COMPARISON.md
+++ b/docs/DEPLOYMENT_MODEL_COMPARISON.md
@@ -86,10 +86,10 @@ before production use.
 
 The Hetzner deployment defaults to the \`eu-central\` network zone, \`fsn1-dc14\`,
 a single \`cx21\` server, and a 20 GB volume mounted at \`/opt/foundry/data\`.
-\`compute_enabled\` allows Terraform to omit application compute while retaining
-the shared data resources. The module uses a private network and optional
-break-glass SSH CIDR; the application is designed to use a Cloudflare Tunnel
-for outward-facing access.
+\`compute_enabled=false\` deletes both the server and its managed data volume;
+it is not a data-preserving compute switch. The module uses a private network
+and optional break-glass SSH CIDR; the application is designed to use a
+Cloudflare Tunnel for outward-facing access.
 
 Choose this model for a simple, cost-sensitive service where a single host is
 an acceptable availability boundary. It has no configured replicated database,
@@ -121,11 +121,11 @@ taxes, and service availability change by date, account, and region.
 | Observability | Logs, metrics, dashboards, alerts | Retain enough telemetry for incident investigation and chargeback | Reduced diagnosis and audit history |
 
 For a low-cost experiment, Hetzner is the only deployment whose Terraform
-profile is explicitly single-server and offers \`compute_enabled\` as an
-application-compute switch. That lowers steady-state compute scope, but it is
-not a substitute for recovery design. AWS, Azure, and GCP defaults should be
-treated as production-oriented managed-service profiles; reducing their counts
-or protections requires a fresh plan review and an explicit availability/RPO
+profile is explicitly single-server. Its current \`compute_enabled\` behavior
+removes the managed data volume along with the server, so it must not be used
+for a cost-saving pause. AWS, Azure, and GCP defaults should be treated as
+production-oriented managed-service profiles; reducing their counts or
+protections requires a fresh plan review and an explicit availability/RPO
 decision.
 
 ## Selection guide
@@ -147,7 +147,7 @@ Choose based on the operational outcome, not a single unit-price comparison:
 | Database availability | Multi-AZ RDS default | DB HA enabled by default | Managed Cloud SQL; multi-region is disabled by default | No managed database in this deployment |
 | Secret handling | Sensitive Terraform inputs and IAM integration; review state handling | Key Vault security module and managed identity wiring | Secrets module and service-account IAM wiring | Sensitive variables; protect tfvars/state and host access |
 | Network exposure | Private app/database tiers, security groups, ALB/CDN | NSGs, private endpoints, Key Vault/storage private DNS | Cloud SQL public IP disabled; firewall design requires restricted admin CIDRs | Tunnel-oriented ingress plus optional SSH CIDR; host remains the trust boundary |
-| Recovery posture | RDS retention plus S3/backup components | DB backups and Recovery Services/managed storage components | Disk snapshot policy and managed DB/storage components | Operator must maintain and test independent backups |
+| Recovery posture | RDS automated-backup retention and versioned S3 buckets; no scheduled application-volume snapshot in the active deployment | DB backup controls plus Recovery Services VM backup and managed storage components | Cloud SQL automated backups and versioned Cloud Storage buckets; no attached disk snapshot policy in the active deployment | Operator must maintain and test independent off-server archives; Hetzner Server backups exclude the attached Volume |
 
 Terraform state can contain sensitive values or resource metadata even when
 variables are marked sensitive. Use a protected remote backend, least-privilege

--- a/infrastructure/deployments/hetzner/README.md
+++ b/infrastructure/deployments/hetzner/README.md
@@ -69,7 +69,15 @@ The Terraform defaults are `cx21`, `fsn1-dc14`, and a 20 GB volume. Treat them a
 
 As of 2026-07-20, repository planning material budgets this deployment at roughly **€6–8/month** for a small server and 20 GB volume, before optional services, taxes, backups, or transfer-related charges. This is an estimate, not a guarantee; confirm the current region, server type, volume, traffic, and backup pricing in the [Hetzner Cloud pricing page](https://www.hetzner.com/cloud/) before applying.
 
-To request a larger data volume, change `data_volume_size_gb` and inspect the plan before applying. Volume growth and server-type changes are provider operations with possible restart or maintenance impact; take and verify an off-server backup first. The module does not expose an in-place server power-state control, so do not assume a Terraform apply will "pause" a server without replacement effects.
+To request a larger data volume, change `data_volume_size_gb` and inspect the
+plan before applying. Volume growth and server-type changes are provider
+operations with possible restart or maintenance impact; take and verify an
+off-server backup first. Increasing the variable grows the Hetzner block
+volume, but this module does not grow an existing ext4 filesystem; complete the
+manual filesystem step in [Resize](#resize) before relying on the added
+capacity. The module also does not expose an in-place server power-state
+control, so do not assume a Terraform apply will "pause" a server without
+replacement effects.
 
 ## Backup and recovery
 
@@ -78,35 +86,83 @@ Terraform state is not a backup. The Foundry data volume contains the state that
 ### Off-server backup procedure
 
 1. **Manual prerequisite:** ensure a tested SSH/console route to the server and an encrypted off-server destination owned by the operator (for example, an approved backup host or object storage workflow). Do not put destination credentials in Terraform variables.
-2. Schedule a maintenance window, stop Foundry for a consistent application-level archive, and archive the mounted data directory. The volume is mounted at the configured `data_mount_path` (default `/opt/foundry/data`).
+2. Schedule a maintenance window and verify that the expected data volume is mounted. From the repository's `infrastructure/deployments/hetzner` directory, stream the tested archive helper to the server so no permanent script installation is required:
 
    ```bash
-   # Run on the server after verifying the mount with: findmnt /opt/foundry/data
-   cd /opt/foundry
-   sudo docker compose stop foundry
-   sudo tar --numeric-owner -C /opt/foundry/data -czf /tmp/foundry-data-$(date +%F).tgz .
-   sudo docker compose start foundry
+   server_ip="$(terraform output -raw server_public_ipv4)"
+   archive_name="foundry-data-$(date +%F).tgz"
+   backup_dir="/root/foundry-backups"
+
+   ssh root@"${server_ip}" 'findmnt /opt/foundry/data'
+   ssh root@"${server_ip}" "install -d -m 700 ${backup_dir}"
+   ssh root@"${server_ip}" 'cd /opt/foundry && docker compose stop foundry'
+   ssh root@"${server_ip}" \
+     "bash -s -- backup /opt/foundry/data ${backup_dir}/${archive_name}" \
+     < ../../../scripts/hetzner-data-archive.sh
+   ssh root@"${server_ip}" 'cd /opt/foundry && docker compose start foundry'
    ```
 
-3. Transfer the archive to the approved off-server destination, verify its checksum there, and record the restore instructions and retention date. Remove the temporary local archive only after verification.
-4. Optionally create a Hetzner volume snapshot/backup through the **Hetzner console or an approved operator workflow**. That provider-side copy is useful for rapid recovery but is not an off-provider backup and does not replace step 3.
+   If Foundry does not restart, keep the maintenance window active and resolve
+   that failure before reopening player traffic.
+
+3. Transfer both files to the approved encrypted off-server destination, verify the checksum after transfer, and record the restore instructions and retention date:
+
+   ```bash
+   scp root@"${server_ip}":"${backup_dir}/${archive_name}" .
+   scp root@"${server_ip}":"${backup_dir}/${archive_name}.sha256" .
+   shasum -a 256 -c "${archive_name}.sha256"
+   ```
+
+   On Linux, use `sha256sum -c` instead. Remove the server's temporary archive
+   and checksum only after the off-server copies verify.
+4. Hetzner Server Backups and Snapshots cover only the server's boot disk; they
+   exclude attached Volumes, and Hetzner does not provide Volume backups or
+   snapshots. They can help reconstruct server configuration, but they do not
+   protect `/opt/foundry/data`. The verified off-server application archive is
+   the data-recovery copy documented here.
 5. Periodically test a restore in a non-production environment. A backup is only trustworthy after a successful restore test.
 
 ### Restore procedure
 
 1. **Manual prerequisite:** use the Hetzner console/operator workflow to recover or replace infrastructure as needed, and keep the server isolated from player traffic until validation completes.
 2. Apply this deployment to create the server and data volume, then wait for cloud-init and Docker to finish. Confirm the volume mount path with `findmnt`.
-3. Stop Foundry, copy the verified off-server archive to the server, extract it into the mounted data directory with ownership preserved, then start Foundry:
+3. Verify the off-server checksum, upload both files into a private root-owned
+   directory, and stop Foundry. Because the freshly started container may
+   already have created `Config`, `Data`, or `Logs`, run the helper's quarantine
+   command before restore. It moves application-created content into a private
+   `.restore-quarantine.*` directory on the same volume and reports that path;
+   it does not delete it. Restore then accepts only the fresh `.formatted`
+   marker, empty `lost+found`, and that quarantine directory. It refuses a
+   checksum mismatch, unsafe archive paths, symlink inputs, the reserved
+   quarantine namespace in an archive, or any other destination content:
 
    ```bash
-   cd /opt/foundry
-   sudo docker compose stop foundry
-   sudo tar --numeric-owner -C /opt/foundry/data -xzf /path/to/verified/foundry-data.tgz
-   sudo docker compose start foundry
-   sudo docker logs --tail=200 foundry
+   server_ip="$(terraform output -raw server_public_ipv4)"
+   archive_name="foundry-data-REPLACE-WITH-BACKUP-DATE.tgz"
+   backup_dir="/root/foundry-backups"
+
+   shasum -a 256 -c "${archive_name}.sha256"
+   ssh root@"${server_ip}" "install -d -m 700 ${backup_dir}"
+   scp "${archive_name}" "${archive_name}.sha256" \
+     root@"${server_ip}":"${backup_dir}/"
+   ssh root@"${server_ip}" 'findmnt /opt/foundry/data'
+   ssh root@"${server_ip}" 'cd /opt/foundry && docker compose stop foundry'
+   ssh root@"${server_ip}" \
+     "bash -s -- quarantine /opt/foundry/data" \
+     < ../../../scripts/hetzner-data-archive.sh
+   ssh root@"${server_ip}" \
+     "bash -s -- restore ${backup_dir}/${archive_name} /opt/foundry/data" \
+     < ../../../scripts/hetzner-data-archive.sh
+   ssh root@"${server_ip}" 'cd /opt/foundry && docker compose start foundry'
+   ssh root@"${server_ip}" 'docker logs --tail=200 foundry'
    ```
 
-4. Verify worlds, assets, user access, Cloudflare Tunnel connectivity, and application logs before reopening access.
+4. Verify worlds, assets, user access, Cloudflare Tunnel connectivity, and
+   application logs before reopening access. Keep the reported quarantine
+   directory through the rollback window; inspect and remove it only after the
+   restored environment and a new off-server backup have been accepted. The
+   helper deliberately excludes top-level `.restore-quarantine.*` directories
+   from backups, so the rollback copy is not duplicated into future archives.
 
 The Terraform module has no input for attaching an existing restored volume. If recovery requires a provider-restored volume rather than an application-level archive, the attach/import steps are a **manual operator procedure** outside this configuration; plan and test them before an incident.
 
@@ -141,9 +197,39 @@ Do not use `compute_enabled=false` as a cost-saving pause unless a tested backup
 1. Create and verify an off-server backup.
 2. Change `server_type` or increase `data_volume_size_gb` in `config/foundry.auto.tfvars`.
 3. From this directory, run the normal `terraform plan` command and review whether the provider will stop, replace, or otherwise disrupt the server.
-4. Apply only during a maintenance window, then verify the application, mount, and tunnel.
+4. Apply only during a maintenance window.
+5. When the plan grows `data_volume_size_gb`, SSH to the server and expand the
+   existing ext4 filesystem. The cloud-init volume setup exits when it finds an
+   already formatted volume, so Terraform does not perform this step:
+
+   ```bash
+   data_device="$(findmnt -n -o SOURCE /opt/foundry/data)"
+   test "$(findmnt -n -o FSTYPE /opt/foundry/data)" = "ext4"
+   sudo resize2fs "${data_device}"
+   df -hT /opt/foundry/data
+   ```
+
+   Confirm that `df` shows the requested usable size. If the filesystem is not
+   ext4 or the source device is unexpected, stop and follow Hetzner's
+   [official Volume resize procedure](https://docs.hetzner.com/cloud/volumes/faq/)
+   instead of guessing.
+6. Verify the application, mount, and tunnel.
 
 Shrinking a volume is not represented by this module; do not attempt it through a smaller variable value without a separate migration and restore plan.
+
+### Temporary game-session scaling
+
+For a planned high-attendance session, measure normal CPU and memory first,
+create a verified off-server backup, and plan a larger `server_type`. Apply the
+change during a maintenance window before players arrive, then verify the mount,
+Foundry, and tunnel using the routine-monitoring commands above. Keep the larger
+size through the session and watch CPU, memory, disk, and application logs.
+
+After the session, retain and verify another off-server backup, plan the original
+smaller `server_type`, and review whether Terraform will stop or replace the
+server before applying. This is operator-scheduled vertical scaling, not
+autoscaling; it can cause downtime, and a replacement plan can be destructive.
+The data volume cannot be shrunk with this workflow.
 
 ### Destroy
 
@@ -155,17 +241,65 @@ terraform destroy \
 
 Destroying this deployment deletes the server and the Terraform-managed data volume. Confirm that an off-server backup has been verified before running it. The network and firewall are also managed resources and are removed by destroy.
 
+## How Hetzner differs from AWS, Azure, and GCP
+
+The four repository deployments do not provide equivalent operating models.
+Use the full
+[deployment model comparison](../../../docs/DEPLOYMENT_MODEL_COMPARISON.md)
+for selection decisions; the issue-critical differences are summarized here:
+
+| Concern | Hetzner deployment | AWS deployment | Azure deployment | GCP deployment |
+| --- | --- | --- | --- | --- |
+| **Availability** | One server and one volume, with no failover or autoscaling | Two-instance application baseline behind an ALB and Multi-AZ RDS | Two-instance VM scale set behind a load balancer with database HA enabled | Two-instance managed group behind a load balancer; Cloud SQL is managed, while multi-region is disabled by default |
+| **Database** | No managed database; application state remains operator-managed on the attached volume | Managed PostgreSQL RDS with Multi-AZ enabled by default | Managed MySQL flexible server with HA enabled by default | Managed PostgreSQL Cloud SQL; public IP is disabled by default |
+| **Backup** | No scheduled backup resource; operators must test off-server archives, and Hetzner Server backups exclude the attached Volume | RDS automated retention and versioned S3 are configured, but no scheduled application-volume snapshot is active | Database backup controls, geo-redundant backup, and Recovery Services VM backup are configured | Cloud SQL automated backups and versioned buckets are configured, but no attached-disk snapshot policy is active |
+| **Monitoring** | Console, host, Docker, Foundry, and Cloudflare checks are operator-run; no Terraform-managed alerts or retention | CloudWatch dashboards, logs, and alarms are part of the deployment | Azure Monitor, Log Analytics, Application Insights, and alerts are integrated | Google monitoring, logging, dashboards, and alerts are integrated |
+
 ## Operational limits and trade-offs
 
 - **Availability:** one server, one volume, one region, and no failover mean provider, host, network, Cloudflare, Docker, or volume failure can cause an outage.
 - **Recovery:** no automated backup or restore orchestration is supplied. Recovery time and data-loss exposure depend on the operator's tested off-server backups and manual console access.
 - **Security:** public Foundry access is designed to flow through Cloudflare Tunnel, and SSH is closed by default. Cloudflare routing/Access configuration and secure credential rotation remain operator responsibilities. A broad SSH CIDR weakens the intended posture.
+- **Data residency:** choose the Hetzner location deliberately and verify its
+  legal, contractual, and organizational fit. Terraform places the server and
+  volume in the selected location, but off-server archive storage, Cloudflare
+  traffic, support access, and operator downloads can move or copy data
+  elsewhere.
+- **Support:** this model relies on Hetzner infrastructure support plus
+  operator-run Linux, Docker, Foundry, Cloudflare, monitoring, and recovery. It
+  does not include the managed database, autoscaling, or integrated operations
+  controls present in the hyperscale deployments.
 - **Data lifecycle:** the current `compute_enabled` implementation does not retain its managed data volume. Treat all teardown-like operations as destructive unless a reviewed plan proves otherwise.
 - **Operations:** there are no Terraform-managed alerts, managed patching, snapshot schedule, autoscaling, or multi-node capacity. Ubuntu package updates and cloud-init run at first boot; ongoing patching and monitoring are operator work.
+
+## Migration path to AWS, Azure, or GCP
+
+This repository does not provide an in-place Terraform migration. Treat a move
+as a controlled application-data migration:
+
+1. Select the target deployment using the
+   [provider comparison](../../../docs/DEPLOYMENT_MODEL_COMPARISON.md), confirm
+   its region, capacity, identity, database, storage, DNS, and cost decisions,
+   and deploy it as a separate environment.
+2. Test the target with non-production Foundry data and document how the
+   Hetzner archive maps to the target provider's persistent application-data
+   path. Managed database and object-storage services are separate from the
+   single-volume Hetzner layout and require an application-specific import
+   plan.
+3. Schedule downtime, stop Foundry on Hetzner, create and verify a final
+   off-server archive, then restore or import it into the isolated target.
+4. Validate worlds, assets, users, modules, licenses, logs, backups, and target
+   monitoring before changing Cloudflare/DNS routing.
+5. Keep the Hetzner environment and final archive intact through the rollback
+   window. Destroy it only after target acceptance and another verified target
+   backup.
 
 ## References
 
 - [Hetzner Cloud documentation](https://docs.hetzner.cloud)
+- [Hetzner Volume limitations](https://docs.hetzner.com/cloud/volumes/overview/)
+- [Hetzner Server Backup and Snapshot scope](https://docs.hetzner.com/cloud/servers/backups-snapshots/overview/)
 - [Hetzner Cloud Terraform provider](https://registry.terraform.io/providers/hetznercloud/hcloud/latest/docs)
 - [Cloudflare Tunnel documentation](https://developers.cloudflare.com/cloudflare-one/connections/connect-networks/)
 - [Foundry VTT Docker image](https://github.com/felddy/foundryvtt-docker)
+- [Tested Hetzner data archive helper](../../../scripts/hetzner-data-archive.sh)

--- a/infrastructure/deployments/hetzner/variables.tf
+++ b/infrastructure/deployments/hetzner/variables.tf
@@ -57,7 +57,7 @@ variable "data_volume_size_gb" {
 
 # ===== Spin up/down =====
 variable "compute_enabled" {
-  description = "Whether LegendForge application compute should be created or suspended while preserving shared data."
+  description = "Whether to create the Hetzner server and data volume. Setting false deletes the server and managed data volume."
   type        = bool
   default     = true
 }

--- a/infrastructure/modules/providers/hetzner/variables.tf
+++ b/infrastructure/modules/providers/hetzner/variables.tf
@@ -57,7 +57,7 @@ variable "data_volume_size_gb" {
 
 # ===== Spin up/down =====
 variable "compute_enabled" {
-  description = "Whether LegendForge application compute should be created or suspended while preserving shared data."
+  description = "Whether to create the Hetzner server and data volume. Setting false deletes the server and managed data volume."
   type        = bool
   default     = true
 }

--- a/scripts/hetzner-data-archive.sh
+++ b/scripts/hetzner-data-archive.sh
@@ -1,0 +1,314 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+usage() {
+  cat >&2 <<'USAGE'
+Usage:
+  hetzner-data-archive.sh backup <source-directory> <archive.tgz>
+  hetzner-data-archive.sh quarantine <destination-directory>
+  hetzner-data-archive.sh restore <archive.tgz> <destination-directory>
+
+The backup command creates <archive.tgz> and <archive.tgz>.sha256.
+The quarantine command moves application-created destination content into a
+private .restore-quarantine.* directory on the same filesystem.
+The restore command verifies that sidecar before extracting into an empty
+destination directory or a fresh Hetzner volume containing only the bootstrap
+.formatted marker, an empty lost+found directory, and one quarantine directory.
+USAGE
+  exit 64
+}
+
+sha256_file() {
+  local file_path="$1"
+
+  if command -v sha256sum >/dev/null 2>&1; then
+    sha256sum -- "${file_path}" | awk '{print $1}'
+  elif command -v shasum >/dev/null 2>&1; then
+    shasum -a 256 -- "${file_path}" | awk '{print $1}'
+  else
+    echo "sha256sum or shasum is required." >&2
+    return 1
+  fi
+}
+
+validate_archive_members() {
+  local archive_path="$1"
+
+  if ! command -v python3 >/dev/null 2>&1; then
+    echo "python3 is required to validate archive paths before restore." >&2
+    return 1
+  fi
+
+  python3 - "${archive_path}" <<'PY'
+import pathlib
+import sys
+import tarfile
+
+
+def fail(message: str) -> None:
+    print(f"Unsafe archive member: {message}", file=sys.stderr)
+    raise SystemExit(1)
+
+
+def normalized_parts(path: pathlib.PurePosixPath) -> list[str]:
+    parts: list[str] = []
+    for part in path.parts:
+        if part in ("", "."):
+            continue
+        if part == "..":
+            if not parts:
+                fail(str(path))
+            parts.pop()
+            continue
+        parts.append(part)
+    return parts
+
+
+archive = pathlib.Path(sys.argv[1])
+with tarfile.open(archive, mode="r:gz") as bundle:
+    for member in bundle.getmembers():
+        member_path = pathlib.PurePosixPath(member.name)
+        if member_path.is_absolute() or ".." in member_path.parts:
+            fail(member.name)
+        member_parts = normalized_parts(member_path)
+        if member_parts and member_parts[0].startswith(".restore-quarantine."):
+            fail(f"{member.name} uses the reserved restore-quarantine namespace")
+
+        if member.issym() or member.islnk():
+            fail(f"{member.name} has unsupported link type")
+        if member.isdev() or member.isfifo():
+            fail(f"{member.name} has unsupported special-file type")
+PY
+}
+
+restore_destination_is_ready() {
+  local destination_directory="$1"
+  local entry
+  local entry_name
+  local quarantine_count=0
+
+  for entry in \
+    "${destination_directory}"/.[!.]* \
+    "${destination_directory}"/..?* \
+    "${destination_directory}"/*; do
+    if [[ ! -e "${entry}" && ! -L "${entry}" ]]; then
+      continue
+    fi
+    entry_name="$(basename "${entry}")"
+    case "${entry_name}" in
+      .formatted)
+        if [[ -L "${entry}" || ! -f "${entry}" || -s "${entry}" ]]; then
+          return 1
+        fi
+        ;;
+      lost+found)
+        if [[ -L "${entry}" || ! -d "${entry}" ]] ||
+          [[ -n "$(find "${entry}" -mindepth 1 -print -quit)" ]]; then
+          return 1
+        fi
+        ;;
+      .restore-quarantine.*)
+        if [[ -L "${entry}" || ! -d "${entry}" ]]; then
+          return 1
+        fi
+        quarantine_count=$((quarantine_count + 1))
+        if [[ "${quarantine_count}" -gt 1 ]]; then
+          return 1
+        fi
+        ;;
+      *)
+        return 1
+        ;;
+    esac
+  done
+}
+
+quarantine_existing_data() {
+  local destination_directory="$1"
+  local quarantine_directory=""
+  local entry
+  local entry_name
+  local moved_any=false
+
+  if [[ -L "${destination_directory}" || ! -d "${destination_directory}" ]]; then
+    echo "Quarantine destination is not a directory: ${destination_directory}" >&2
+    return 1
+  fi
+
+  for entry in \
+    "${destination_directory}"/.[!.]* \
+    "${destination_directory}"/..?* \
+    "${destination_directory}"/*; do
+    if [[ ! -e "${entry}" && ! -L "${entry}" ]]; then
+      continue
+    fi
+    entry_name="$(basename "${entry}")"
+    case "${entry_name}" in
+      .formatted | lost+found)
+        continue
+        ;;
+      .restore-quarantine.*)
+        echo "A restore quarantine already exists: ${entry}" >&2
+        return 1
+        ;;
+    esac
+
+    if [[ -z "${quarantine_directory}" ]]; then
+      umask 077
+      quarantine_directory="$(mktemp -d "${destination_directory}/.restore-quarantine.XXXXXX")"
+    fi
+    mv -- "${entry}" "${quarantine_directory}/"
+    moved_any=true
+  done
+
+  if [[ "${moved_any}" == true ]]; then
+    printf 'Quarantined existing data in %s\n' "${quarantine_directory}"
+  else
+    printf 'No application-created data required quarantine in %s\n' "${destination_directory}"
+  fi
+}
+
+backup_data() {
+  local source_directory="$1"
+  local archive_path="$2"
+  local archive_parent
+  local archive_absolute
+  local checksum_path
+  local source_absolute
+  local checksum
+  local completed=false
+  local archive_published=false
+  local checksum_published=false
+  local temporary_archive=""
+  local temporary_checksum=""
+
+  if [[ ! -d "${source_directory}" ]]; then
+    echo "Backup source is not a directory: ${source_directory}" >&2
+    return 1
+  fi
+  if [[ -e "${archive_path}" || -L "${archive_path}" ||
+    -e "${archive_path}.sha256" || -L "${archive_path}.sha256" ]]; then
+    echo "Refusing to overwrite an existing archive or checksum: ${archive_path}" >&2
+    return 1
+  fi
+
+  source_absolute="$(cd "${source_directory}" && pwd -P)"
+  archive_parent="$(cd "$(dirname "${archive_path}")" && pwd -P)"
+  archive_absolute="${archive_parent}/$(basename "${archive_path}")"
+  checksum_path="${archive_absolute}.sha256"
+
+  case "${archive_absolute}" in
+    "${source_absolute}" | "${source_absolute}"/*)
+      echo "Archive must be outside the source directory." >&2
+      return 1
+      ;;
+  esac
+
+  cleanup_partial_backup() {
+    if [[ "${completed}" != true ]]; then
+      if [[ "${checksum_published}" == true ]]; then
+        rm -f -- "${checksum_path}"
+      fi
+      if [[ "${archive_published}" == true ]]; then
+        rm -f -- "${archive_absolute}"
+      fi
+    fi
+    if [[ -n "${temporary_archive}" ]]; then
+      rm -f -- "${temporary_archive}"
+    fi
+    if [[ -n "${temporary_checksum}" ]]; then
+      rm -f -- "${temporary_checksum}"
+    fi
+  }
+  trap cleanup_partial_backup EXIT
+
+  umask 077
+  temporary_archive="$(mktemp "${archive_parent}/.$(basename "${archive_absolute}").tmp.XXXXXX")"
+  temporary_checksum="$(mktemp "${archive_parent}/.$(basename "${checksum_path}").tmp.XXXXXX")"
+  tar -C "${source_absolute}" \
+    --exclude='./.restore-quarantine.*' \
+    -czf "${temporary_archive}" .
+  checksum="$(sha256_file "${temporary_archive}")"
+  printf '%s  %s\n' "${checksum}" "$(basename "${archive_absolute}")" >"${temporary_checksum}"
+
+  if ! ln -- "${temporary_archive}" "${archive_absolute}"; then
+    echo "Refusing to overwrite an archive created concurrently: ${archive_absolute}" >&2
+    return 1
+  fi
+  archive_published=true
+  if ! ln -- "${temporary_checksum}" "${checksum_path}"; then
+    echo "Refusing to overwrite a checksum created concurrently: ${checksum_path}" >&2
+    return 1
+  fi
+  checksum_published=true
+
+  completed=true
+  cleanup_partial_backup
+  trap - EXIT
+  printf 'Created %s and %s\n' "${archive_absolute}" "${checksum_path}"
+}
+
+restore_data() {
+  local archive_path="$1"
+  local destination_directory="$2"
+  local checksum_path="${archive_path}.sha256"
+  local expected_checksum
+  local actual_checksum
+
+  if [[ -L "${archive_path}" || ! -f "${archive_path}" ]]; then
+    echo "Archive does not exist: ${archive_path}" >&2
+    return 1
+  fi
+  if [[ -L "${checksum_path}" || ! -f "${checksum_path}" ]]; then
+    echo "Checksum sidecar does not exist: ${checksum_path}" >&2
+    return 1
+  fi
+  if [[ -L "${destination_directory}" || ! -d "${destination_directory}" ]]; then
+    echo "Restore destination is not a directory: ${destination_directory}" >&2
+    return 1
+  fi
+  if ! restore_destination_is_ready "${destination_directory}"; then
+    echo "Restore destination must be empty or contain only a fresh Hetzner bootstrap marker: ${destination_directory}" >&2
+    return 1
+  fi
+
+  expected_checksum="$(awk 'NR == 1 {print $1}' "${checksum_path}")"
+  if [[ ! "${expected_checksum}" =~ ^[0-9a-fA-F]{64}$ ]]; then
+    echo "Checksum sidecar is invalid: ${checksum_path}" >&2
+    return 1
+  fi
+  actual_checksum="$(sha256_file "${archive_path}")"
+  if [[ "${actual_checksum}" != "${expected_checksum}" ]]; then
+    echo "Archive checksum verification failed: ${archive_path}" >&2
+    return 1
+  fi
+
+  validate_archive_members "${archive_path}"
+  tar -C "${destination_directory}" -xzf "${archive_path}"
+  printf 'Restored %s into %s\n' "${archive_path}" "${destination_directory}"
+}
+
+command_name="${1:-}"
+case "${command_name}" in
+  backup)
+    if [[ "$#" -ne 3 ]]; then
+      usage
+    fi
+    backup_data "$2" "$3"
+    ;;
+  quarantine)
+    if [[ "$#" -ne 2 ]]; then
+      usage
+    fi
+    quarantine_existing_data "$2"
+    ;;
+  restore)
+    if [[ "$#" -ne 3 ]]; then
+      usage
+    fi
+    restore_data "$2" "$3"
+    ;;
+  *)
+    usage
+    ;;
+esac

--- a/tests/test_issue_47_acceptance.py
+++ b/tests/test_issue_47_acceptance.py
@@ -1,0 +1,357 @@
+from __future__ import annotations
+
+import hashlib
+import io
+from pathlib import Path
+import shutil
+import subprocess
+import tarfile
+import tempfile
+import unittest
+
+
+REPOSITORY_ROOT = Path(__file__).resolve().parents[1]
+ARCHIVE_SCRIPT = REPOSITORY_ROOT / "scripts" / "hetzner-data-archive.sh"
+
+
+class HetznerArchiveTests(unittest.TestCase):
+    def run_archive(self, *arguments: object, check: bool = True) -> subprocess.CompletedProcess[str]:
+        return subprocess.run(
+            ["bash", str(ARCHIVE_SCRIPT), *(str(argument) for argument in arguments)],
+            check=check,
+            capture_output=True,
+            text=True,
+        )
+
+    def test_backup_off_server_copy_and_restore_round_trip(self) -> None:
+        with tempfile.TemporaryDirectory() as temporary:
+            workspace = Path(temporary)
+            source = workspace / "foundry data"
+            source.mkdir()
+            (source / "worlds" / "campaign one").mkdir(parents=True)
+            (source / "worlds" / "campaign one" / "world.json").write_text(
+                '{"title":"LegendForge"}\n',
+                encoding="utf-8",
+            )
+            (source / "assets").mkdir()
+            (source / "assets" / "token image.txt").write_bytes(b"token-data\x00")
+
+            local_archive = workspace / "foundry-data.tgz"
+            self.run_archive("backup", source, local_archive)
+            self.assertTrue(local_archive.is_file())
+            self.assertTrue(Path(f"{local_archive}.sha256").is_file())
+
+            off_server = workspace / "off-server"
+            off_server.mkdir()
+            copied_archive = off_server / local_archive.name
+            shutil.copy2(local_archive, copied_archive)
+            shutil.copy2(Path(f"{local_archive}.sha256"), Path(f"{copied_archive}.sha256"))
+
+            expected_files = {
+                path.relative_to(source): path.read_bytes()
+                for path in source.rglob("*")
+                if path.is_file()
+            }
+            shutil.rmtree(source)
+
+            restored = workspace / "restored"
+            restored.mkdir()
+            self.run_archive("restore", copied_archive, restored)
+            restored_files = {
+                path.relative_to(restored): path.read_bytes()
+                for path in restored.rglob("*")
+                if path.is_file()
+            }
+            self.assertEqual(expected_files, restored_files)
+
+    def test_backup_refuses_to_overwrite_existing_archive(self) -> None:
+        with tempfile.TemporaryDirectory() as temporary:
+            workspace = Path(temporary)
+            source = workspace / "source"
+            source.mkdir()
+            archive = workspace / "backup.tgz"
+            archive.write_bytes(b"existing")
+
+            result = self.run_archive("backup", source, archive, check=False)
+            self.assertNotEqual(0, result.returncode)
+            self.assertIn("Refusing to overwrite", result.stderr)
+            self.assertEqual(b"existing", archive.read_bytes())
+
+    def test_backup_refuses_dangling_archive_or_checksum_symlinks(self) -> None:
+        with tempfile.TemporaryDirectory() as temporary:
+            workspace = Path(temporary)
+            source = workspace / "source"
+            source.mkdir()
+            (source / "world.json").write_text("{}\n", encoding="utf-8")
+
+            for suffix in ("", ".sha256"):
+                with self.subTest(suffix=suffix):
+                    archive = workspace / f"backup-{len(suffix)}.tgz"
+                    redirected = workspace / f"redirected-{len(suffix)}.tgz"
+                    Path(f"{archive}{suffix}").symlink_to(redirected)
+
+                    result = self.run_archive("backup", source, archive, check=False)
+
+                    self.assertNotEqual(0, result.returncode)
+                    self.assertIn("Refusing to overwrite", result.stderr)
+                    self.assertFalse(redirected.exists())
+
+    def test_restore_rejects_checksum_corruption(self) -> None:
+        with tempfile.TemporaryDirectory() as temporary:
+            workspace = Path(temporary)
+            source = workspace / "source"
+            source.mkdir()
+            (source / "world.json").write_text("{}\n", encoding="utf-8")
+            archive = workspace / "backup.tgz"
+            self.run_archive("backup", source, archive)
+            archive.write_bytes(archive.read_bytes() + b"corrupt")
+            destination = workspace / "destination"
+            destination.mkdir()
+
+            result = self.run_archive("restore", archive, destination, check=False)
+            self.assertNotEqual(0, result.returncode)
+            self.assertIn("checksum verification failed", result.stderr)
+            self.assertEqual([], list(destination.iterdir()))
+
+    def test_restore_refuses_nonempty_destination(self) -> None:
+        with tempfile.TemporaryDirectory() as temporary:
+            workspace = Path(temporary)
+            source = workspace / "source"
+            source.mkdir()
+            (source / "world.json").write_text("{}\n", encoding="utf-8")
+            archive = workspace / "backup.tgz"
+            self.run_archive("backup", source, archive)
+            destination = workspace / "destination"
+            destination.mkdir()
+            sentinel = destination / "keep.txt"
+            sentinel.write_text("keep\n", encoding="utf-8")
+
+            result = self.run_archive("restore", archive, destination, check=False)
+            self.assertNotEqual(0, result.returncode)
+            self.assertIn("must be empty", result.stderr)
+            self.assertEqual("keep\n", sentinel.read_text(encoding="utf-8"))
+
+    def test_restore_accepts_fresh_hetzner_bootstrap_state(self) -> None:
+        with tempfile.TemporaryDirectory() as temporary:
+            workspace = Path(temporary)
+            source = workspace / "source"
+            source.mkdir()
+            (source / "world.json").write_text("{}\n", encoding="utf-8")
+            archive = workspace / "backup.tgz"
+            self.run_archive("backup", source, archive)
+            destination = workspace / "destination"
+            destination.mkdir()
+            (destination / ".formatted").touch()
+            (destination / "lost+found").mkdir()
+
+            self.run_archive("restore", archive, destination)
+
+            self.assertEqual(
+                "{}\n",
+                (destination / "world.json").read_text(encoding="utf-8"),
+            )
+            self.assertTrue((destination / ".formatted").is_file())
+
+    def test_quarantine_and_restore_post_bootstrap_foundry_data(self) -> None:
+        with tempfile.TemporaryDirectory() as temporary:
+            workspace = Path(temporary)
+            source = workspace / "source"
+            source.mkdir()
+            (source / "Data" / "worlds").mkdir(parents=True)
+            (source / "Data" / "worlds" / "restored.json").write_text(
+                '{"restored":true}\n',
+                encoding="utf-8",
+            )
+            archive = workspace / "backup.tgz"
+            self.run_archive("backup", source, archive)
+
+            destination = workspace / "destination"
+            destination.mkdir()
+            (destination / ".formatted").touch()
+            (destination / "lost+found").mkdir()
+            (destination / "Config").mkdir()
+            (destination / "Config" / "options.json").write_text(
+                '{"bootstrap":true}\n',
+                encoding="utf-8",
+            )
+            (destination / "Logs").mkdir()
+
+            result = self.run_archive("quarantine", destination)
+            quarantine = next(destination.glob(".restore-quarantine.*"))
+            self.assertIn(str(quarantine), result.stdout)
+            self.assertEqual(
+                '{"bootstrap":true}\n',
+                (quarantine / "Config" / "options.json").read_text(encoding="utf-8"),
+            )
+
+            self.run_archive("restore", archive, destination)
+
+            self.assertEqual(
+                '{"restored":true}\n',
+                (destination / "Data" / "worlds" / "restored.json").read_text(
+                    encoding="utf-8",
+                ),
+            )
+            self.assertTrue((quarantine / "Logs").is_dir())
+
+            post_restore_archive = workspace / "post-restore.tgz"
+            self.run_archive("backup", destination, post_restore_archive)
+            second_destination = workspace / "second-destination"
+            second_destination.mkdir()
+            self.run_archive("restore", post_restore_archive, second_destination)
+            self.assertEqual(
+                '{"restored":true}\n',
+                (
+                    second_destination / "Data" / "worlds" / "restored.json"
+                ).read_text(encoding="utf-8"),
+            )
+            self.assertEqual(
+                [],
+                list(second_destination.glob(".restore-quarantine.*")),
+            )
+
+    def test_restore_rejects_path_traversal(self) -> None:
+        with tempfile.TemporaryDirectory() as temporary:
+            workspace = Path(temporary)
+            archive = workspace / "unsafe.tgz"
+            payload = b"escape"
+            with tarfile.open(archive, "w:gz") as bundle:
+                member = tarfile.TarInfo("../escape.txt")
+                member.size = len(payload)
+                bundle.addfile(member, io.BytesIO(payload))
+            checksum = hashlib.sha256(archive.read_bytes()).hexdigest()
+            Path(f"{archive}.sha256").write_text(
+                f"{checksum}  {archive.name}\n",
+                encoding="utf-8",
+            )
+            destination = workspace / "destination"
+            destination.mkdir()
+
+            result = self.run_archive("restore", archive, destination, check=False)
+            self.assertNotEqual(0, result.returncode)
+            self.assertIn("Unsafe archive member", result.stderr)
+            self.assertFalse((workspace / "escape.txt").exists())
+
+    def test_restore_rejects_links_before_quarantine_can_be_overwritten(self) -> None:
+        for link_type in (tarfile.SYMTYPE, tarfile.LNKTYPE):
+            with self.subTest(link_type=link_type), tempfile.TemporaryDirectory() as temporary:
+                workspace = Path(temporary)
+                archive = workspace / "unsafe-link.tgz"
+                quarantine_name = ".restore-quarantine.rollback"
+                payload = b"overwritten"
+
+                with tarfile.open(archive, "w:gz") as bundle:
+                    link = tarfile.TarInfo("pivot")
+                    link.type = link_type
+                    link.linkname = quarantine_name
+                    bundle.addfile(link)
+
+                    member = tarfile.TarInfo("pivot/protected.txt")
+                    member.size = len(payload)
+                    bundle.addfile(member, io.BytesIO(payload))
+
+                checksum = hashlib.sha256(archive.read_bytes()).hexdigest()
+                Path(f"{archive}.sha256").write_text(
+                    f"{checksum}  {archive.name}\n",
+                    encoding="utf-8",
+                )
+
+                destination = workspace / "destination"
+                destination.mkdir()
+                quarantine = destination / quarantine_name
+                quarantine.mkdir()
+                protected = quarantine / "protected.txt"
+                protected.write_text("keep\n", encoding="utf-8")
+
+                result = self.run_archive("restore", archive, destination, check=False)
+
+                self.assertNotEqual(0, result.returncode)
+                self.assertIn("unsupported link type", result.stderr)
+                self.assertEqual("keep\n", protected.read_text(encoding="utf-8"))
+                self.assertFalse((destination / "pivot").exists())
+
+
+class Issue47DocumentationTests(unittest.TestCase):
+    def read(self, relative_path: str) -> str:
+        return (REPOSITORY_ROOT / relative_path).read_text(encoding="utf-8")
+
+    def test_required_navigation_links_are_present(self) -> None:
+        index = self.read("DOCUMENTATION_INDEX.md")
+        comparison = self.read("docs/DEPLOYMENT_MODEL_COMPARISON.md")
+        sidebar = self.read("wiki/_Sidebar.md")
+
+        self.assertIn(
+            "[Deployment model comparison](docs/DEPLOYMENT_MODEL_COMPARISON.md)",
+            index,
+        )
+        self.assertIn(
+            "[Hetzner deployment guide](infrastructure/deployments/hetzner/README.md)",
+            index,
+        )
+        self.assertIn(
+            "[Hetzner deployment README](../infrastructure/deployments/hetzner/README.md)",
+            comparison,
+        )
+        self.assertIn(
+            "docs/DEPLOYMENT_MODEL_COMPARISON.md",
+            sidebar,
+        )
+        self.assertIn(
+            "infrastructure/deployments/hetzner/README.md",
+            sidebar,
+        )
+
+    def test_dangerous_lifecycle_guidance_is_removed(self) -> None:
+        root_readme = self.read("README.md")
+        comparison = self.read("docs/DEPLOYMENT_MODEL_COMPARISON.md")
+        wiki_how_to = self.read("wiki/How-To.md")
+        deployment_variables = self.read("infrastructure/deployments/hetzner/variables.tf")
+        module_variables = self.read("infrastructure/modules/providers/hetzner/variables.tf")
+
+        self.assertNotIn("hcloud volume create-backup", root_readme)
+        self.assertNotIn("All platforms support spin-down", root_readme)
+        self.assertNotIn("Daily snapshots via AWS Backup", root_readme)
+        self.assertNotIn("Daily snapshots via Disk Resource Policy", root_readme)
+        self.assertNotIn("Disk snapshot policy and managed DB", comparison)
+        self.assertIn("deletes both the server and its managed data volume", comparison)
+        self.assertIn("deletes the server and managed data volume", wiki_how_to)
+        self.assertIn("deletes the server and managed data volume", deployment_variables)
+        self.assertIn("deletes the server and managed data volume", module_variables)
+
+    def test_hetzner_guide_covers_all_issue_47_operating_topics(self) -> None:
+        guide = self.read("infrastructure/deployments/hetzner/README.md")
+
+        for required_heading in (
+            "### Temporary game-session scaling",
+            "## Operational limits and trade-offs",
+            "## Migration path to AWS, Azure, or GCP",
+        ):
+            with self.subTest(required_heading=required_heading):
+                self.assertIn(required_heading, guide)
+
+        self.assertIn("**Data residency:**", guide)
+        self.assertIn("**Support:**", guide)
+        self.assertIn("Server Backups and Snapshots cover only the server's boot disk", guide)
+        self.assertIn("docker compose stop foundry", guide)
+        self.assertIn("bash -s -- quarantine /opt/foundry/data", guide)
+        self.assertIn('backup_dir="/root/foundry-backups"', guide)
+        self.assertIn("sudo resize2fs", guide)
+        self.assertIn("this module does not grow an existing ext4 filesystem", guide)
+        self.assertIn("official Volume resize procedure", guide)
+
+        for provider in ("AWS deployment", "Azure deployment", "GCP deployment"):
+            with self.subTest(provider=provider):
+                self.assertIn(provider, guide)
+
+        for comparison_category in (
+            "| **Availability** |",
+            "| **Database** |",
+            "| **Backup** |",
+            "| **Monitoring** |",
+        ):
+            with self.subTest(comparison_category=comparison_category):
+                self.assertIn(comparison_category, guide)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/wiki/How-To.md
+++ b/wiki/How-To.md
@@ -71,15 +71,20 @@ Use provider-specific resource names when inspecting details with `terraform sta
 
 ## How to Spin Down and Bring Back Compute
 
-LegendForge supports a cost-control pattern where compute can be disabled while persistent data remains.
+Persistence behavior differs by provider. Review the generated Terraform plan
+and the provider-specific deployment guide before disabling compute.
 
-Set:
+For Hetzner, setting:
 
 ```hcl
 compute_enabled = false
 ```
 
-Then re-apply Terraform. Re-enable later and apply again to bring the runtime back online.
+deletes the server and managed data volume. It is not a data-preserving pause.
+Use a manual server power action only after reviewing its billing and Terraform
+state consequences, and verify an off-server backup before any teardown-like
+operation. See the
+[Hetzner lifecycle guide](https://github.com/sodejm/LegendForge-CloudCampaigns/blob/main/infrastructure/deployments/hetzner/README.md#pause-and-resume).
 
 ## How to Prepare for Upgrades
 

--- a/wiki/_Sidebar.md
+++ b/wiki/_Sidebar.md
@@ -13,5 +13,7 @@
 
 - [Main README](https://github.com/sodejm/LegendForge-CloudCampaigns/blob/main/README.md)
 - [Documentation Index](https://github.com/sodejm/LegendForge-CloudCampaigns/blob/main/DOCUMENTATION_INDEX.md)
+- [Deployment Model Comparison](https://github.com/sodejm/LegendForge-CloudCampaigns/blob/main/docs/DEPLOYMENT_MODEL_COMPARISON.md)
+- [Hetzner Deployment Guide](https://github.com/sodejm/LegendForge-CloudCampaigns/blob/main/infrastructure/deployments/hetzner/README.md)
 - [Project Philosophy](https://github.com/sodejm/LegendForge-CloudCampaigns/blob/main/PROJECT_PHILOSOPHY.md)
 - [Supported Systems](https://github.com/sodejm/LegendForge-CloudCampaigns/blob/main/SUPPORTED_SYSTEMS.md)


### PR DESCRIPTION
## Summary

- add a local-only Hetzner data archive workflow with backup, quarantine, checksum verification, safe restore, and off-server-copy guidance
- harden restore behavior against traversal, symlink, special-file, race, overwrite, and rollback hazards
- add 11 standard-library acceptance tests and register them in pre-commit
- correct Hetzner lifecycle, scaling, availability, monitoring, data residency, support, migration, and backup documentation
- add navigation from the README, documentation index, comparison guide, and wiki

## Acceptance criteria

- cloud availability, database, backup, and monitoring differences are documented
- backup and restore are tested locally through an off-server round trip
- low-cost sizing, lifecycle, and temporary scaling guidance is documented
- Hetzner guidance is linked from the comparison, index, and wiki surfaces

## Validation

- 11/11 issue acceptance tests passed
- Bash syntax validation passed
- pre-commit stage passed
- pre-push Semgrep, Terraform, and TruffleHog gates passed
- Terraform validate and TFLint passed for AWS, Azure, GCP, and Hetzner
- final exact-commit Dependabot discovery: zero updates across GitHub Actions and all four Terraform deployments
- diff check passed

Issue #47 closure implementation. The issue will be updated with final hosted evidence and closed after this PR merges.
