### PR TITLE
Validate Hetzner archives before publishing

### DIFF
--- a/infrastructure/deployments/hetzner/README.md
+++ b/infrastructure/deployments/hetzner/README.md
@@ -103,7 +103,10 @@ Terraform state is not a backup. The Foundry data volume contains the state that
    ```
 
    If Foundry does not restart, keep the maintenance window active and resolve
-   that failure before reopening player traffic.
+   that failure before reopening player traffic. Before publishing either
+   output, the helper validates the temporary archive and rejects symbolic or
+   hard links, devices, and FIFOs. A rejected backup leaves neither the archive
+   nor its checksum sidecar.
 
 3. Transfer both files to the approved encrypted off-server destination, verify the checksum after transfer, and record the restore instructions and retention date:
 

--- a/scripts/hetzner-data-archive.sh
+++ b/scripts/hetzner-data-archive.sh
@@ -35,7 +35,7 @@ validate_archive_members() {
   local archive_path="$1"
 
   if ! command -v python3 >/dev/null 2>&1; then
-    echo "python3 is required to validate archive paths before restore." >&2
+    echo "python3 is required to validate archive contents." >&2
     return 1
   fi
 
@@ -228,6 +228,7 @@ backup_data() {
   tar -C "${source_absolute}" \
     --exclude='./.restore-quarantine.*' \
     -czf "${temporary_archive}" .
+  validate_archive_members "${temporary_archive}"
   checksum="$(sha256_file "${temporary_archive}")"
   printf '%s  %s\n' "${checksum}" "$(basename "${archive_absolute}")" >"${temporary_checksum}"
 

--- a/tests/test_issue_47_acceptance.py
+++ b/tests/test_issue_47_acceptance.py
@@ -2,6 +2,7 @@ from __future__ import annotations
 
 import hashlib
 import io
+import os
 from pathlib import Path
 import shutil
 import subprocess
@@ -15,11 +16,17 @@ ARCHIVE_SCRIPT = REPOSITORY_ROOT / "scripts" / "hetzner-data-archive.sh"
 
 
 class HetznerArchiveTests(unittest.TestCase):
-    def run_archive(self, *arguments: object, check: bool = True) -> subprocess.CompletedProcess[str]:
+    def run_archive(
+        self,
+        *arguments: object,
+        check: bool = True,
+        environment: dict[str, str] | None = None,
+    ) -> subprocess.CompletedProcess[str]:
         return subprocess.run(
             ["bash", str(ARCHIVE_SCRIPT), *(str(argument) for argument in arguments)],
             check=check,
             capture_output=True,
+            env=environment,
             text=True,
         )
 
@@ -95,6 +102,69 @@ class HetznerArchiveTests(unittest.TestCase):
                     self.assertNotEqual(0, result.returncode)
                     self.assertIn("Refusing to overwrite", result.stderr)
                     self.assertFalse(redirected.exists())
+
+    def test_backup_rejects_unsafe_members_before_publishing_artifacts(self) -> None:
+        unsafe_types = {
+            "symlink": tarfile.SYMTYPE,
+            "hardlink": tarfile.LNKTYPE,
+            "fifo": tarfile.FIFOTYPE,
+            "character-device": tarfile.CHRTYPE,
+            "block-device": tarfile.BLKTYPE,
+        }
+
+        for member_kind, member_type in unsafe_types.items():
+            with self.subTest(member_kind=member_kind), tempfile.TemporaryDirectory() as temporary:
+                workspace = Path(temporary)
+                source = workspace / "source"
+                source.mkdir()
+                fixture_archive = workspace / "unsafe-fixture.tgz"
+                with tarfile.open(fixture_archive, "w:gz") as bundle:
+                    member = tarfile.TarInfo(f"unsafe-{member_kind}")
+                    member.type = member_type
+                    if member_type in (tarfile.SYMTYPE, tarfile.LNKTYPE):
+                        member.linkname = "target"
+                    if member_type in (tarfile.CHRTYPE, tarfile.BLKTYPE):
+                        member.devmajor = 1
+                        member.devminor = 3
+                    bundle.addfile(member)
+
+                fake_bin = workspace / "fake-bin"
+                fake_bin.mkdir()
+                fake_tar = fake_bin / "tar"
+                fake_tar.write_text(
+                    """#!/usr/bin/env bash
+set -euo pipefail
+while [[ "$#" -gt 0 ]]; do
+  if [[ "$1" == "-czf" ]]; then
+    cp "${FIXTURE_ARCHIVE}" "$2"
+    exit 0
+  fi
+  shift
+done
+exit 64
+""",
+                    encoding="utf-8",
+                )
+                fake_tar.chmod(0o755)
+
+                archive = workspace / "backup.tgz"
+                environment = {
+                    **os.environ,
+                    "FIXTURE_ARCHIVE": str(fixture_archive),
+                    "PATH": f"{fake_bin}{os.pathsep}{os.environ['PATH']}",
+                }
+                result = self.run_archive(
+                    "backup",
+                    source,
+                    archive,
+                    check=False,
+                    environment=environment,
+                )
+
+                self.assertNotEqual(0, result.returncode)
+                self.assertIn("Unsafe archive member", result.stderr)
+                self.assertFalse(archive.exists())
+                self.assertFalse(Path(f"{archive}.sha256").exists())
 
     def test_restore_rejects_checksum_corruption(self) -> None:
         with tempfile.TemporaryDirectory() as temporary:


### PR DESCRIPTION
## Summary

- validate the temporary Hetzner archive before publishing the archive or checksum
- reject symbolic links, hard links, FIFOs, character devices, and block devices
- ensure failed backups leave neither public artifact
- document the validation boundary and add deterministic rejection coverage

## Validation

- `python3 -m unittest tests/test_issue_47_acceptance.py` (13 passed)
- `bash -n scripts/hetzner-data-archive.sh`
- `TERRAFORM_QUALITY_TARGETS=aws,azure,gcp,hetzner scripts/terraform-quality.sh`
- pre-commit all files
- pre-push Semgrep and TruffleHog gates
- `git diff --check`

Fixes #47