### PR TITLE
Correct active recovery documentation

### DIFF
--- a/docs/DEPLOYMENT_MODEL_COMPARISON.md
+++ b/docs/DEPLOYMENT_MODEL_COMPARISON.md
@@ -147,7 +147,14 @@ Choose based on the operational outcome, not a single unit-price comparison:
 | Database availability | Multi-AZ RDS default | DB HA enabled by default | Managed Cloud SQL; multi-region is disabled by default | No managed database in this deployment |
 | Secret handling | Sensitive Terraform inputs and IAM integration; review state handling | Key Vault security module and managed identity wiring | Secrets module and service-account IAM wiring | Sensitive variables; protect tfvars/state and host access |
 | Network exposure | Private app/database tiers, security groups, ALB/CDN | NSGs, private endpoints, Key Vault/storage private DNS | Cloud SQL public IP disabled; firewall design requires restricted admin CIDRs | Tunnel-oriented ingress plus optional SSH CIDR; host remains the trust boundary |
-| Recovery posture | RDS automated-backup retention and versioned S3 buckets; no scheduled application-volume snapshot in the active deployment | DB backup controls plus Recovery Services VM backup and managed storage components | Cloud SQL automated backups and versioned Cloud Storage buckets; no attached disk snapshot policy in the active deployment | Operator must maintain and test independent off-server archives; Hetzner Server backups exclude the attached Volume |
+| Recovery posture | RDS automated-backup retention and versioned S3 buckets; no scheduled application-volume snapshot in the active deployment | 35-day, geo-redundant Flexible Server backups and GZRS object storage by default; no blob versioning/soft delete or Recovery Services VM/disk backup in the active deployment | Cloud SQL automated backups/PITR and versioned Cloud Storage buckets; no snapshot policy is attached to application data disks in the active deployment | Operator must maintain and test independent off-server archives; Hetzner Server backups exclude the attached Volume |
+
+Database backups and object-storage redundancy/versioning do not protect
+application data stored on compute disks. The active Azure deployment wires
+neither Recovery Services VM backup nor disk snapshots. The active GCP
+deployment creates per-instance persistent data disks but attaches no snapshot
+resource policy. Treat these compute-disk recovery gaps as unprotected until
+they are explicitly implemented and restore-tested.
 
 Terraform state can contain sensitive values or resource metadata even when
 variables are marked sensitive. Use a protected remote backend, least-privilege

--- a/tests/test_issue_58_acceptance.py
+++ b/tests/test_issue_58_acceptance.py
@@ -1,0 +1,190 @@
+from __future__ import annotations
+
+from pathlib import Path
+import re
+import unittest
+
+
+REPOSITORY_ROOT = Path(__file__).resolve().parents[1]
+
+
+def read_repository_file(relative_path: str) -> str:
+    return (REPOSITORY_ROOT / relative_path).read_text(encoding="utf-8")
+
+
+def read_active_module_configuration(deployment_path: str) -> str:
+    deployment_file = REPOSITORY_ROOT / deployment_path
+    deployment = deployment_file.read_text(encoding="utf-8")
+    sources = re.findall(
+        r'(?m)^\s*source\s*=\s*"(\.\./\.\./modules/[^"]+)"\s*$',
+        deployment,
+    )
+    module_files = [
+        terraform_file
+        for source in sources
+        for terraform_file in sorted(
+            (deployment_file.parent / source).resolve().glob("*.tf")
+        )
+    ]
+    return "\n".join(
+        terraform_file.read_text(encoding="utf-8")
+        for terraform_file in module_files
+    )
+
+
+class RecoveryDocumentationTests(unittest.TestCase):
+    def assert_module_source(self, configuration: str, source: str) -> None:
+        self.assertRegex(
+            configuration,
+            rf'(?m)^\s*source\s*=\s*"{re.escape(source)}"\s*$',
+        )
+
+    def test_active_azure_recovery_capabilities_match_documentation(self) -> None:
+        deployment = read_repository_file(
+            "infrastructure/deployments/azure/main.tf"
+        )
+        database = read_repository_file(
+            "infrastructure/modules/azure/database/main.tf"
+        )
+        deployment_variables = read_repository_file(
+            "infrastructure/deployments/azure/variables.tf"
+        )
+        storage_variables = read_repository_file(
+            "infrastructure/modules/azure/storage/variables.tf"
+        )
+        active_modules = read_active_module_configuration(
+            "infrastructure/deployments/azure/main.tf"
+        )
+
+        for source in (
+            "../../modules/azure/database",
+            "../../modules/azure/storage",
+            "../../modules/azure/compute",
+        ):
+            self.assert_module_source(deployment, source)
+        self.assertNotRegex(
+            deployment,
+            r'(?m)^\s*source\s*=\s*"\.\./\.\./modules/azure"\s*$',
+        )
+
+        self.assertIn(
+            "backup_retention_days        = var.backup_retention_days",
+            database,
+        )
+        self.assertIn(
+            "geo_redundant_backup_enabled = "
+            "var.geo_redundant_backup_enabled",
+            database,
+        )
+        self.assertRegex(
+            deployment_variables,
+            r'(?s)variable "backup_retention_days"\s*{[^}]*'
+            r"default\s*=\s*35",
+        )
+        self.assertRegex(
+            deployment_variables,
+            r'(?s)variable "geo_redundant_backup_enabled"\s*{[^}]*'
+            r"default\s*=\s*true",
+        )
+        self.assertRegex(
+            storage_variables,
+            r'(?s)variable "account_replication_type"\s*{[^}]*'
+            r'default\s*=\s*"GZRS"',
+        )
+
+        for unsupported_capability in (
+            "azurerm_recovery_services_vault",
+            "azurerm_backup_protected_vm",
+            "azurerm_snapshot",
+            "versioning_enabled",
+            "delete_retention_policy",
+        ):
+            self.assertNotIn(unsupported_capability, active_modules)
+
+    def test_active_gcp_recovery_capabilities_match_documentation(self) -> None:
+        deployment = read_repository_file("infrastructure/deployments/gcp/main.tf")
+        cloud_sql = read_repository_file(
+            "infrastructure/modules/gcp-cloudsql/main.tf"
+        )
+        storage = read_repository_file(
+            "infrastructure/modules/gcp-storage/main.tf"
+        )
+        compute = read_repository_file(
+            "infrastructure/modules/gcp-compute/main.tf"
+        )
+        active_modules = read_active_module_configuration(
+            "infrastructure/deployments/gcp/main.tf"
+        )
+
+        for source in (
+            "../../modules/gcp-cloudsql",
+            "../../modules/gcp-storage",
+            "../../modules/gcp-compute",
+        ):
+            self.assert_module_source(deployment, source)
+        self.assertNotRegex(
+            deployment,
+            r'(?m)^\s*source\s*=\s*"\.\./\.\./modules/gcp"\s*$',
+        )
+
+        self.assertIn("backup_configuration {", cloud_sql)
+        self.assertIn("point_in_time_recovery_enabled = true", cloud_sql)
+        self.assertIn("retained_backups = 30", cloud_sql)
+        enabled_versioning_blocks = re.findall(
+            r"(?s)versioning\s*{[^}]*enabled\s*=\s*true",
+            storage,
+        )
+        self.assertGreaterEqual(len(enabled_versioning_blocks), 3)
+        self.assertIn('type            = "PERSISTENT"', compute)
+        self.assertIn("auto_delete     = false", compute)
+        for unsupported_capability in (
+            "google_compute_resource_policy",
+            "google_compute_disk_resource_policy_attachment",
+            "resource_policies",
+        ):
+            self.assertNotIn(unsupported_capability, active_modules)
+
+    def test_recovery_comparison_states_active_compute_disk_gaps(self) -> None:
+        comparison = read_repository_file(
+            "docs/DEPLOYMENT_MODEL_COMPARISON.md"
+        )
+        recovery_row = next(
+            line
+            for line in comparison.splitlines()
+            if line.startswith("| Recovery posture |")
+        )
+
+        self.assertIn(
+            "35-day, geo-redundant Flexible Server backups and GZRS "
+            "object storage by default",
+            recovery_row,
+        )
+        self.assertIn(
+            "no blob versioning/soft delete or Recovery Services VM/disk "
+            "backup in the active deployment",
+            recovery_row,
+        )
+        self.assertIn(
+            "Cloud SQL automated backups/PITR and versioned Cloud Storage "
+            "buckets",
+            recovery_row,
+        )
+        self.assertIn(
+            "no snapshot policy is attached to application data disks in "
+            "the active deployment",
+            recovery_row,
+        )
+        self.assertNotIn(
+            "DB backup controls plus Recovery Services VM backup",
+            recovery_row,
+        )
+        self.assertIn(
+            "Database backups and object-storage redundancy/versioning do "
+            "not protect",
+            comparison,
+        )
+        self.assertIn("compute-disk recovery gaps", comparison)
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Summary

- align the recovery comparison with the infrastructure currently wired by the active deployments
- state explicitly that Azure and GCP compute recovery is not currently wired
- retain the supported database and object-storage recovery claims
- add deterministic acceptance checks for active-module references and recovery statements

## Validation

- `python3 -m unittest tests/test_issue_58_acceptance.py` (3 passed)
- full pre-commit gate, including the full test suite and staged TruffleHog
- pre-push Semgrep and TruffleHog gates
- local Markdown link audit
- `git diff --check`

The legacy Azure/GCP monolithic modules have no active in-repository callers, but external consumers cannot be ruled out, so this focused change does not delete them.

Fixes #58