### PR TITLE
Correct GCP storage bill of materials

### DIFF
--- a/docs/DEPLOYMENT_MODEL_COMPARISON.md
+++ b/docs/DEPLOYMENT_MODEL_COMPARISON.md
@@ -9,7 +9,7 @@ and region.
 ## Scope and method
 
 The comparison is derived from the Terraform defaults and module wiring in this
-repository as of **2026-07-20**. It covers the deployments in
+repository as of **2026-07-25**. It covers the deployments in
 [\`infrastructure/deployments/aws\`](../infrastructure/deployments/aws),
 [\`azure\`](../infrastructure/deployments/azure),
 [\`gcp\`](../infrastructure/deployments/gcp), and
@@ -29,7 +29,7 @@ backup retention, and any applicable support plan.
 | --- | --- | --- | --- |
 | AWS | Two-AZ VPC, two \`t3.medium\` application instances, Multi-AZ \`db.t3.medium\` RDS, ALB, CloudFront, S3, CloudWatch | Production workload where AWS managed HA, backups, and AWS operations are required | Highest service count and several persistent/network charges |
 | Azure | VM scale set at two \`Standard_D4s_v5\` instances, flexible database at \`Standard_B2s\`, private endpoints, Key Vault, storage/CDN, monitoring | Azure-standard identity, networking, and operations estate | High default compute footprint and many managed services |
-| GCP | Two \`n2-standard-2\` application instances, Cloud SQL \`db-custom-2-7680\`, 500 GB data disk, load balancer, CDN, Cloud Armor, monitoring | GCP environment needing private Cloud SQL, Google-managed edge controls, and optional multi-region design | Large default data disk and managed platform components materially affect spend |
+| GCP | Two \`n2-standard-2\` application instances, Cloud SQL \`db-custom-2-7680\`, two 500 GB \`pd-ssd\` data disks (one per instance; at least 1 TB active), load balancer, CDN, Cloud Armor, monitoring | GCP environment needing private Cloud SQL, Google-managed edge controls, and optional multi-region design | Per-instance persistent disks and managed platform components materially affect spend |
 | Hetzner | One \`cx21\` server, 20 GB attached volume, private network, Cloudflare Tunnel | Cost-sensitive single-server campaign with operator-managed recovery | No in-repository HA or managed database; recovery and capacity are operator responsibilities |
 
 The first three are multi-service cloud deployments. Hetzner is deliberately a
@@ -71,16 +71,23 @@ possible footprint.
 The GCP deployment defaults to \`us-central1\` with a \`us-east1\` secondary
 region defined but \`enable_multi_region = false\`. It starts a managed instance
 group at two \`n2-standard-2\` instances (maximum five), uses PostgreSQL 15
-Cloud SQL at \`db-custom-2-7680\`, and provisions a 500 GB data disk. CDN and
+Cloud SQL at \`db-custom-2-7680\`, and provisions one 500 GB \`pd-ssd\` data disk
+for every managed instance group member. The default minimum of two instances
+therefore keeps at least 2 × 500 GB, or 1 TB, of active data disks. CDN and
 Cloud Armor are enabled by default; Cloud SQL public IP is disabled and
 deletion protection is enabled. The root composes VPC, IAM, secrets, Cloud SQL,
 storage, compute, load balancing, and monitoring modules.
 
 Choose this model when private managed database access, Google edge controls,
-and GCP-native monitoring are required. Treat the 500 GB disk and managed
-database as explicit baseline commitments even for a small player population.
-The default \`admin_source_ranges\` includes \`0.0.0.0/0\` and must be narrowed
-before production use.
+and GCP-native monitoring are required. Every additional active group member
+adds another 500 GB \`pd-ssd\` disk, so the default maximum of five instances can
+reach 2.5 TB of active data disks. These disks set \`auto_delete = false\`;
+retained disks from scale-in or replacement remain separately billable and are
+not included in the active-group total. The active deployment configures no
+snapshot policy for these data disks, so any operator-created snapshots are a
+separate storage cost rather than part of the baseline. The default
+\`admin_source_ranges\` includes \`0.0.0.0/0\` and must be narrowed before
+production use.
 
 ### Hetzner
 
@@ -107,7 +114,7 @@ taxes, and service availability change by date, account, and region.
 | --- | --- | --- | --- |
 | AWS | \`us-east-1\`; USD; review date 2026-07-20 | [AWS Pricing Calculator](https://calculator.aws/) | 2 \`t3.medium\` instances at desired capacity (allow 2–4), Multi-AZ \`db.t3.medium\`, 100 GB RDS storage, 3,000 IOPS/125 throughput, ALB, CloudFront, Route53, S3, CloudWatch, NAT/VPC networking, 30-day database/log retention |
 | Azure | \`eastus\`; USD; review date 2026-07-20 | [Azure Pricing Calculator](https://azure.microsoft.com/pricing/calculator/) | 2 \`Standard_D4s_v5\` VMSS instances (allow 2–10), \`Standard_B2s\` flexible database with 100 GB, HA, geo-redundant backups, NAT/public IP/load balancer, Key Vault, private endpoints, storage/CDN, Log Analytics/Application Insights/alerts |
-| GCP | \`us-central1\`; USD; review date 2026-07-20 | [Google Cloud Pricing Calculator](https://cloud.google.com/products/calculator) | 2 \`n2-standard-2\` instances (allow 2–5), 500 GB data disk/snapshots, \`db-custom-2-7680\` Cloud SQL, load balancer, CDN, Cloud Armor, NAT/VPC, storage, Secret Manager, monitoring/logging |
+| GCP | \`us-central1\`; USD; review date 2026-07-25 | [Google Cloud Pricing Calculator](https://cloud.google.com/products/calculator) | 2 \`n2-standard-2\` instances (allow 2–5), at least 2 × 500 GB \`pd-ssd\` data disks (1 TB active at the default minimum; one per group member, up to 2.5 TB active at five), \`db-custom-2-7680\` Cloud SQL, load balancer, CDN, Cloud Armor, NAT/VPC, storage, Secret Manager, monitoring/logging; retained non-auto-delete disks and any operator-created snapshots are separate |
 | Hetzner | \`fsn1-dc14\` / \`eu-central\`; EUR; review date 2026-07-20 | [Hetzner Cloud pricing](https://www.hetzner.com/cloud/) | 1 \`cx21\`, 20 GB volume, network/IP/traffic charges or allowances as applicable, plus external backup storage and Cloudflare services if used |
 
 ### Cost drivers and safe levers

--- a/infrastructure/deployments/gcp/ARCHITECTURE.md
+++ b/infrastructure/deployments/gcp/ARCHITECTURE.md
@@ -132,7 +132,7 @@
   - Ubuntu 24.04 LTS
   - 2 vCPU, 8GB RAM (configurable)
   - 100GB boot disk (pd-standard)
-  - 500GB data disk (pd-ssd, persistent, not auto-deleted)
+  - 500GB data disk per instance (pd-ssd, persistent, not auto-deleted)
   - Shielded VM enabled (secure boot, vTPM, integrity monitoring)
   - Service account with minimal permissions
 
@@ -147,6 +147,14 @@
   - Max replicas: 5
   - CPU target: 70%
   - Optional: Memory-based scaling
+
+Each active replica receives its own data disk. The default minimum therefore
+uses at least 2 × 500 GB, or 1 TB, of active \`pd-ssd\` capacity; each additional
+active replica adds another 500 GB, up to 2.5 TB at the default maximum of five.
+Because the disks are not auto-deleted, disks retained after scale-in or
+replacement are separately billable and are not part of that active capacity.
+The active deployment does not configure a snapshot policy for these disks;
+any operator-created snapshots are separate storage costs.
 
 - **Health Checks**:
   - HTTP GET to port 30030, path /
@@ -481,7 +489,8 @@
 
 - **2-5 instances**: 50-250 concurrent players
 - **Database**: 2 vCPU, 7.5GB RAM supports 500+ concurrent users
-- **Storage**: 500GB instance disk, unlimited cloud storage
+- **Storage**: 500GB per active instance (at least 1TB at the default minimum),
+  unlimited cloud storage
 
 ---
 
@@ -494,7 +503,7 @@
 | Compute | n2-standard-2 | n2-standard-4 | n2-standard-8 |
 | Instances | 2-3 | 2-5 | 3-10 |
 | Database | db-custom-2-7680 | db-custom-4-16384 | db-custom-8-32768 |
-| Storage | 500 GB | 2 TB | 5 TB |
+| Data disk per instance | 500 GB | 2 TB | 5 TB |
 | Est. Cost | $350/mo | $700/mo | $1500/mo |
 
 ### Cost Reduction

--- a/tests/test_issue_57_acceptance.py
+++ b/tests/test_issue_57_acceptance.py
@@ -1,0 +1,129 @@
+from __future__ import annotations
+
+from pathlib import Path
+import re
+import unittest
+
+
+REPOSITORY_ROOT = Path(__file__).resolve().parents[1]
+GCP_DEPLOYMENT = REPOSITORY_ROOT / "infrastructure" / "deployments" / "gcp"
+GCP_COMPUTE_MODULE = REPOSITORY_ROOT / "infrastructure" / "modules" / "gcp-compute"
+COMPARISON_GUIDE = REPOSITORY_ROOT / "docs" / "DEPLOYMENT_MODEL_COMPARISON.md"
+ARCHITECTURE_GUIDE = GCP_DEPLOYMENT / "ARCHITECTURE.md"
+
+
+def numeric_variable_default(source: str, variable_name: str) -> int:
+    variable = re.search(
+        rf'variable\s+"{re.escape(variable_name)}"\s*\{{(?P<body>.*?)^\}}',
+        source,
+        flags=re.DOTALL | re.MULTILINE,
+    )
+    if variable is None:
+        raise AssertionError(f"Variable {variable_name!r} was not found")
+
+    default = re.search(
+        r"^\s*default\s*=\s*(?P<value>\d+)\s*$",
+        variable.group("body"),
+        flags=re.MULTILINE,
+    )
+    if default is None:
+        raise AssertionError(f"Numeric default for {variable_name!r} was not found")
+
+    return int(default.group("value"))
+
+
+class GcpStorageBillOfMaterialsTests(unittest.TestCase):
+    @classmethod
+    def setUpClass(cls) -> None:
+        cls.deployment_variables = (GCP_DEPLOYMENT / "variables.tf").read_text(
+            encoding="utf-8"
+        )
+        cls.deployment_main = (GCP_DEPLOYMENT / "main.tf").read_text(encoding="utf-8")
+        cls.compute_main = (GCP_COMPUTE_MODULE / "main.tf").read_text(encoding="utf-8")
+        cls.comparison = COMPARISON_GUIDE.read_text(encoding="utf-8")
+        cls.architecture = ARCHITECTURE_GUIDE.read_text(encoding="utf-8")
+        cls.comparison_flat = " ".join(cls.comparison.split())
+        cls.architecture_flat = " ".join(cls.architecture.split())
+
+    def test_active_deployment_defaults_require_two_500_gb_disks(self) -> None:
+        self.assertEqual(
+            500,
+            numeric_variable_default(self.deployment_variables, "data_disk_size_gb"),
+        )
+        self.assertEqual(
+            2,
+            numeric_variable_default(self.deployment_variables, "min_instances"),
+        )
+        self.assertEqual(
+            5,
+            numeric_variable_default(self.deployment_variables, "max_instances"),
+        )
+        self.assertIn('source = "../../modules/gcp-compute"', self.deployment_main)
+        for variable_name in ("data_disk_size_gb", "min_instances", "max_instances"):
+            with self.subTest(variable_name=variable_name):
+                self.assertRegex(
+                    self.deployment_main,
+                    rf"{variable_name}\s*=\s*var\.{variable_name}",
+                )
+
+    def test_each_active_group_member_has_a_non_auto_delete_pd_ssd(self) -> None:
+        self.assertRegex(
+            self.compute_main,
+            re.compile(
+                r"# Persistent data disk.*?"
+                r'disk_type\s*=\s*"pd-ssd".*?'
+                r"disk_size_gb\s*=\s*var\.data_disk_size_gb.*?"
+                r"auto_delete\s*=\s*false.*?"
+                r"source_snapshot\s*=\s*null",
+                flags=re.DOTALL,
+            ),
+        )
+        self.assertIn("target_size = var.min_instances", self.compute_main)
+        self.assertRegex(
+            self.compute_main,
+            r"min_replicas\s*=\s*var\.min_instances",
+        )
+        self.assertRegex(
+            self.compute_main,
+            r"max_replicas\s*=\s*var\.max_instances",
+        )
+        self.assertNotIn("google_compute_resource_policy", self.compute_main)
+        self.assertNotIn(
+            "google_compute_disk_resource_policy_attachment",
+            self.compute_main,
+        )
+
+    def test_comparison_guide_counts_active_and_retained_storage_separately(
+        self,
+    ) -> None:
+        required_language = (
+            "at least 2 × 500 GB",
+            "1 TB",
+            "one 500 GB \\`pd-ssd\\` data disk",
+            "Every additional active group member adds another 500 GB",
+            "retained disks from scale-in or replacement remain separately billable",
+            "configures no snapshot policy",
+            "operator-created snapshots are a separate storage cost",
+        )
+        for phrase in required_language:
+            with self.subTest(phrase=phrase):
+                self.assertIn(phrase, self.comparison_flat)
+
+        self.assertNotIn("500 GB data disk/snapshots", self.comparison)
+
+    def test_architecture_guide_describes_per_instance_scaling(self) -> None:
+        required_language = (
+            "500GB data disk per instance",
+            "at least 2 × 500 GB",
+            "each additional active replica adds another 500 GB",
+            "disks retained after scale-in or",
+            "does not configure a snapshot policy",
+            "Data disk per instance",
+        )
+        for phrase in required_language:
+            with self.subTest(phrase=phrase):
+                self.assertIn(phrase, self.architecture_flat)
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Summary

- document the default GCP MIG storage as two 500 GB `pd-ssd` disks per instance
- separate active-disk, retained-disk, and snapshot costs
- add deterministic configuration/documentation acceptance tests

Fixes #57.

## Validation

- `python3 -m unittest tests/test_issue_57_acceptance.py`
- `pre-commit run --all-files`
- `git diff --check origin/main...HEAD`
- local Semgrep and TruffleHog push gates

## Dead-code and interface audit

The active deployment uses `gcp-compute`. The unreferenced legacy snapshot-bearing GCP module was inspected but retained because external consumers cannot be disproven; this PR changes no Terraform interface.