### PR TITLE
Repair repository and published-Wiki navigation

### DIFF
--- a/DOCUMENTATION_INDEX.md
+++ b/DOCUMENTATION_INDEX.md
@@ -48,6 +48,8 @@ This index is the navigation hub for LegendForge documentation. It highlights th
 - **[Hetzner deployment guide](infrastructure/deployments/hetzner/README.md)** - Single-server topology, security, tested off-server archive workflow, recovery, and destructive lifecycle limits
 
 ### GitHub Wiki Source Pages
+- **[Published GitHub Wiki](https://github.com/sodejm/LegendForge-CloudCampaigns/wiki)** - Rendered operator guides and cross-page navigation
+- **[wiki/README.md](wiki/README.md)** - Source-page index, link conventions, and publication requirement
 - **[wiki/Home.md](wiki/Home.md)** - Wiki landing page and overview
 - **[wiki/Quickstart.md](wiki/Quickstart.md)** - Shortest path to a first deployment
 - **[wiki/Installation.md](wiki/Installation.md)** - Setup prerequisites and configuration inputs
@@ -56,6 +58,11 @@ This index is the navigation hub for LegendForge documentation. It highlights th
 - **[wiki/Prompts.md](wiki/Prompts.md)** - Planning and operational checklist prompts
 - **[wiki/Use-Cases.md](wiki/Use-Cases.md)** - Common deployment and community scenarios
 - **[wiki/Architecture-and-Security.md](wiki/Architecture-and-Security.md)** - Shared architecture and security themes
+
+The `wiki/` files are maintained in this repository, but the rendered GitHub
+Wiki is published separately. Repository readers should use the `.md` source
+links above; page-to-page links in the publishable sources route to the
+published wiki.
 
 ---
 

--- a/README.md
+++ b/README.md
@@ -495,6 +495,8 @@ When switching or adding systems in Foundry:
 - [ATTRIBUTION.md](ATTRIBUTION.md) - Technical attribution and license references
 - [CREDITS.md](CREDITS.md) - Community recognition and acknowledgments
 - [DOCUMENTATION_INDEX.md](DOCUMENTATION_INDEX.md) - Documentation map
+- [Published GitHub Wiki](https://github.com/sodejm/LegendForge-CloudCampaigns/wiki) - Rendered operator guides
+- [Wiki source pages](wiki/README.md) - Maintained source and publication notes
 
 ### Official Documentation
 

--- a/tests/test_issue_59_wiki_links.py
+++ b/tests/test_issue_59_wiki_links.py
@@ -1,0 +1,145 @@
+from __future__ import annotations
+
+from pathlib import Path
+import re
+import unittest
+from urllib.parse import unquote, urlsplit
+
+
+REPOSITORY_ROOT = Path(__file__).resolve().parents[1]
+WIKI_ROOT = REPOSITORY_ROOT / "wiki"
+PUBLISHED_WIKI_BASE = "https://github.com/sodejm/LegendForge-CloudCampaigns/wiki"
+REPOSITORY_BLOB_BASE = (
+    "https://github.com/sodejm/LegendForge-CloudCampaigns/blob/main/"
+)
+WIKI_PAGE_FILES = (
+    "Home.md",
+    "Quickstart.md",
+    "Installation.md",
+    "Provider-Guide.md",
+    "How-To.md",
+    "Prompts.md",
+    "Use-Cases.md",
+    "Architecture-and-Security.md",
+)
+PUBLISHABLE_WIKI_FILES = (*WIKI_PAGE_FILES, "_Sidebar.md")
+MARKDOWN_LINK = re.compile(r"(?<!!)\[[^\]]+\]\(([^)]+)\)")
+
+
+def link_targets(path: Path) -> list[str]:
+    return [
+        target.strip()
+        for target in MARKDOWN_LINK.findall(path.read_text(encoding="utf-8"))
+    ]
+
+
+class Issue59WikiNavigationTests(unittest.TestCase):
+    def test_repository_relative_links_resolve(self) -> None:
+        sources = (
+            REPOSITORY_ROOT / "README.md",
+            REPOSITORY_ROOT / "DOCUMENTATION_INDEX.md",
+            *sorted(WIKI_ROOT.glob("*.md")),
+        )
+
+        for source in sources:
+            for target in link_targets(source):
+                parsed = urlsplit(target)
+                if parsed.scheme or target.startswith("#"):
+                    continue
+
+                relative_path = unquote(parsed.path)
+                if not relative_path:
+                    continue
+
+                resolved = (source.parent / relative_path).resolve()
+                with self.subTest(source=source.relative_to(REPOSITORY_ROOT), target=target):
+                    self.assertTrue(
+                        resolved.exists(),
+                        f"{source.relative_to(REPOSITORY_ROOT)} links to missing {target}",
+                    )
+
+    def test_publishable_pages_avoid_repository_only_or_extensionless_links(self) -> None:
+        page_names = set(WIKI_PAGE_FILES)
+        page_slugs = {Path(name).stem for name in WIKI_PAGE_FILES}
+
+        for filename in PUBLISHABLE_WIKI_FILES:
+            source = WIKI_ROOT / filename
+            for target in link_targets(source):
+                parsed = urlsplit(target)
+                if parsed.scheme:
+                    continue
+
+                local_name = Path(unquote(parsed.path)).name
+                with self.subTest(source=filename, target=target):
+                    self.assertNotIn(
+                        local_name,
+                        page_names,
+                        "publishable wiki pages must not use repository-only .md links",
+                    )
+                    self.assertNotIn(
+                        local_name,
+                        page_slugs,
+                        "extensionless wiki links break in the repository source view",
+                    )
+
+    def test_published_wiki_links_name_known_pages(self) -> None:
+        page_slugs = {Path(name).stem for name in WIKI_PAGE_FILES}
+
+        for filename in PUBLISHABLE_WIKI_FILES:
+            source = WIKI_ROOT / filename
+            for target in link_targets(source):
+                if not target.startswith(f"{PUBLISHED_WIKI_BASE}/"):
+                    continue
+
+                slug = unquote(urlsplit(target).path).removeprefix(
+                    "/sodejm/LegendForge-CloudCampaigns/wiki/"
+                )
+                with self.subTest(source=filename, target=target):
+                    self.assertIn(slug, page_slugs)
+
+    def test_wiki_repository_links_name_existing_paths(self) -> None:
+        for source in sorted(WIKI_ROOT.glob("*.md")):
+            for target in link_targets(source):
+                if not target.startswith(REPOSITORY_BLOB_BASE):
+                    continue
+
+                relative_path = unquote(
+                    urlsplit(target.removeprefix(REPOSITORY_BLOB_BASE)).path
+                )
+                with self.subTest(
+                    source=source.relative_to(REPOSITORY_ROOT), target=target
+                ):
+                    self.assertTrue(
+                        (REPOSITORY_ROOT / relative_path).exists(),
+                        f"{source.relative_to(REPOSITORY_ROOT)} links to missing {target}",
+                    )
+
+    def test_sidebar_links_every_published_page(self) -> None:
+        sidebar_targets = set(link_targets(WIKI_ROOT / "_Sidebar.md"))
+        expected_targets = {
+            f"{PUBLISHED_WIKI_BASE}/{Path(filename).stem}"
+            for filename in WIKI_PAGE_FILES
+        }
+        self.assertLessEqual(expected_targets, sidebar_targets)
+
+    def test_source_index_explains_dual_navigation_and_publication(self) -> None:
+        source_index = (WIKI_ROOT / "README.md").read_text(encoding="utf-8")
+
+        for filename in (*WIKI_PAGE_FILES, "_Sidebar.md"):
+            with self.subTest(filename=filename):
+                self.assertIn(f"]({filename})", source_index)
+
+        self.assertIn(f"]({PUBLISHED_WIKI_BASE})", source_index)
+        self.assertIn("does not update the published wiki by itself", source_index)
+        self.assertIn("Do not use extensionless relative targets", source_index)
+
+    def test_repository_entry_points_offer_source_and_published_navigation(self) -> None:
+        for filename in ("README.md", "DOCUMENTATION_INDEX.md"):
+            document = (REPOSITORY_ROOT / filename).read_text(encoding="utf-8")
+            with self.subTest(filename=filename):
+                self.assertIn(f"]({PUBLISHED_WIKI_BASE})", document)
+                self.assertIn("](wiki/README.md)", document)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/wiki/Home.md
+++ b/wiki/Home.md
@@ -8,11 +8,11 @@ It is designed to support **many Foundry-compatible systems** without locking th
 
 If you are new to LegendForge, read these pages in order:
 
-1. [Quickstart](Quickstart)
-2. [Installation](Installation)
-3. [Provider Guide](Provider-Guide)
-4. [How-To](How-To)
-5. [Use Cases](Use-Cases)
+1. [Quickstart](https://github.com/sodejm/LegendForge-CloudCampaigns/wiki/Quickstart)
+2. [Installation](https://github.com/sodejm/LegendForge-CloudCampaigns/wiki/Installation)
+3. [Provider Guide](https://github.com/sodejm/LegendForge-CloudCampaigns/wiki/Provider-Guide)
+4. [How-To](https://github.com/sodejm/LegendForge-CloudCampaigns/wiki/How-To)
+5. [Use Cases](https://github.com/sodejm/LegendForge-CloudCampaigns/wiki/Use-Cases)
 
 ## What LegendForge Covers
 
@@ -44,20 +44,20 @@ If you are new to LegendForge, read these pages in order:
 
 ### New operators
 
-1. [Quickstart](Quickstart)
-2. [Installation](Installation)
-3. [Use Cases](Use-Cases)
+1. [Quickstart](https://github.com/sodejm/LegendForge-CloudCampaigns/wiki/Quickstart)
+2. [Installation](https://github.com/sodejm/LegendForge-CloudCampaigns/wiki/Installation)
+3. [Use Cases](https://github.com/sodejm/LegendForge-CloudCampaigns/wiki/Use-Cases)
 
 ### Deployment operators
 
-1. [Provider Guide](Provider-Guide)
-2. [Architecture and Security](Architecture-and-Security)
-3. [How-To](How-To)
+1. [Provider Guide](https://github.com/sodejm/LegendForge-CloudCampaigns/wiki/Provider-Guide)
+2. [Architecture and Security](https://github.com/sodejm/LegendForge-CloudCampaigns/wiki/Architecture-and-Security)
+3. [How-To](https://github.com/sodejm/LegendForge-CloudCampaigns/wiki/How-To)
 
 ### Contributors and reviewers
 
-1. [Prompts](Prompts)
-2. [Architecture and Security](Architecture-and-Security)
+1. [Prompts](https://github.com/sodejm/LegendForge-CloudCampaigns/wiki/Prompts)
+2. [Architecture and Security](https://github.com/sodejm/LegendForge-CloudCampaigns/wiki/Architecture-and-Security)
 3. Repository docs linked below
 
 ## Key Repository Documents

--- a/wiki/How-To.md
+++ b/wiki/How-To.md
@@ -9,7 +9,7 @@ This page collects common operator tasks using the existing repository guidance.
 - Choose **GCP** for strong monitoring and managed service integrations
 - Choose **Hetzner** for the lowest-cost, simplest production path
 
-See [Provider Guide](Provider-Guide).
+See the [Provider Guide](https://github.com/sodejm/LegendForge-CloudCampaigns/wiki/Provider-Guide).
 
 ## How to Deploy a New Instance
 
@@ -106,6 +106,6 @@ Before major changes:
 
 ## Related Pages
 
-- [Quickstart](Quickstart)
-- [Prompts](Prompts)
-- [Use Cases](Use-Cases)
+- [Quickstart](https://github.com/sodejm/LegendForge-CloudCampaigns/wiki/Quickstart)
+- [Prompts](https://github.com/sodejm/LegendForge-CloudCampaigns/wiki/Prompts)
+- [Use Cases](https://github.com/sodejm/LegendForge-CloudCampaigns/wiki/Use-Cases)

--- a/wiki/Installation.md
+++ b/wiki/Installation.md
@@ -94,6 +94,6 @@ Do not commit this file.
 
 ## Related Pages
 
-- [Quickstart](Quickstart)
-- [Architecture and Security](Architecture-and-Security)
-- [Provider Guide](Provider-Guide)
+- [Quickstart](https://github.com/sodejm/LegendForge-CloudCampaigns/wiki/Quickstart)
+- [Architecture and Security](https://github.com/sodejm/LegendForge-CloudCampaigns/wiki/Architecture-and-Security)
+- [Provider Guide](https://github.com/sodejm/LegendForge-CloudCampaigns/wiki/Provider-Guide)

--- a/wiki/Quickstart.md
+++ b/wiki/Quickstart.md
@@ -94,6 +94,6 @@ terraform apply -var-file="../../../config/foundry.auto.tfvars" -var-file="../..
 
 ## Best Next Pages
 
-- [Installation](Installation)
-- [Provider Guide](Provider-Guide)
-- [How-To](How-To)
+- [Installation](https://github.com/sodejm/LegendForge-CloudCampaigns/wiki/Installation)
+- [Provider Guide](https://github.com/sodejm/LegendForge-CloudCampaigns/wiki/Provider-Guide)
+- [How-To](https://github.com/sodejm/LegendForge-CloudCampaigns/wiki/How-To)

--- a/wiki/README.md
+++ b/wiki/README.md
@@ -4,16 +4,32 @@ This directory contains GitHub wiki-ready Markdown pages built from the current 
 
 Use these files as the source set for the repository wiki:
 
-- `Home.md`
-- `_Sidebar.md`
-- `Quickstart.md`
-- `Installation.md`
-- `How-To.md`
-- `Provider-Guide.md`
-- `Prompts.md`
-- `Use-Cases.md`
-- `Architecture-and-Security.md`
+- [Home.md](Home.md)
+- [_Sidebar.md](_Sidebar.md)
+- [Quickstart.md](Quickstart.md)
+- [Installation.md](Installation.md)
+- [How-To.md](How-To.md)
+- [Provider-Guide.md](Provider-Guide.md)
+- [Prompts.md](Prompts.md)
+- [Use-Cases.md](Use-Cases.md)
+- [Architecture-and-Security.md](Architecture-and-Security.md)
 
 These pages summarize and cross-link the existing LegendForge documentation so they can be published into the GitHub wiki.
 
 Because the GitHub wiki is a separate repository, these files are stored here as the maintained source set for wiki publication.
+
+## Navigation and publication
+
+- Read the rendered pages in the [published GitHub Wiki](https://github.com/sodejm/LegendForge-CloudCampaigns/wiki).
+- Use the `.md` links above when reviewing source files in this repository.
+- Publish source changes to the repository's separate wiki before treating the rendered wiki as current. A merge to this repository does not update the published wiki by itself.
+
+Links between publishable wiki pages use canonical
+`https://github.com/sodejm/LegendForge-CloudCampaigns/wiki/<Page>` URLs. Those
+links work from both this source directory and the rendered wiki. Repository
+documents linked from wiki pages use canonical `blob/main` URLs because the
+published wiki has a separate repository root.
+
+Do not use extensionless relative targets such as `Quickstart` in these source
+files. GitHub Wiki resolves that form after publication, but it is broken when
+the Markdown source is browsed in this repository.

--- a/wiki/_Sidebar.md
+++ b/wiki/_Sidebar.md
@@ -1,13 +1,13 @@
 ## LegendForge Wiki
 
-- [Home](Home)
-- [Quickstart](Quickstart)
-- [Installation](Installation)
-- [Provider Guide](Provider-Guide)
-- [How-To](How-To)
-- [Prompts](Prompts)
-- [Use Cases](Use-Cases)
-- [Architecture and Security](Architecture-and-Security)
+- [Home](https://github.com/sodejm/LegendForge-CloudCampaigns/wiki/Home)
+- [Quickstart](https://github.com/sodejm/LegendForge-CloudCampaigns/wiki/Quickstart)
+- [Installation](https://github.com/sodejm/LegendForge-CloudCampaigns/wiki/Installation)
+- [Provider Guide](https://github.com/sodejm/LegendForge-CloudCampaigns/wiki/Provider-Guide)
+- [How-To](https://github.com/sodejm/LegendForge-CloudCampaigns/wiki/How-To)
+- [Prompts](https://github.com/sodejm/LegendForge-CloudCampaigns/wiki/Prompts)
+- [Use Cases](https://github.com/sodejm/LegendForge-CloudCampaigns/wiki/Use-Cases)
+- [Architecture and Security](https://github.com/sodejm/LegendForge-CloudCampaigns/wiki/Architecture-and-Security)
 
 ## Repository Docs
 


### PR DESCRIPTION
## Summary

- use `.md` repository-source links where GitHub renders repository Markdown
- use stable published-Wiki URLs for cross-surface navigation
- repair root, wiki index, sidebar, and provider navigation
- add deterministic tests that reject stale extensionless repository wiki links

Fixes #59.

## Validation

- `python3 -m unittest tests/test_issue_59_wiki_links.py` (7 tests)
- `pre-commit run --all-files`
- `git diff --check origin/main...HEAD`
- local Semgrep and TruffleHog push gates

## Documentation/dead-code audit

The affected entry points and Wiki source pages were audited together. No code or public module surface is removed; publishing the separate rendered GitHub Wiki remains governed by the repository’s Wiki synchronization backlog.