### PR TITLE
Add provider-neutral post-deployment smoke test

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -23,8 +23,8 @@ repos:
         language: system
         stages: [pre-commit]
 
-      - id: issue-47-acceptance-tests
-        name: Hetzner backup restore and documentation tests
+      - id: acceptance-tests
+        name: Repository acceptance tests
         entry: python3 -m unittest discover -s tests -p "test_*.py"
         language: system
         pass_filenames: false

--- a/README.md
+++ b/README.md
@@ -320,6 +320,31 @@ terraform destroy   -var-file="../../../config/foundry.auto.tfvars"   -var-file=
 ⚠️ **WARNING:** Destroy can delete data volumes. Verify a tested, independent
 backup before continuing.
 
+### Post-Deployment Reachability Smoke Test
+
+After `terraform apply`, verify the public deployment URL with the
+provider-neutral smoke test:
+
+```bash
+# Read only the foundry_url output from the selected deployment directory.
+scripts/post-deploy-smoke-test.sh infrastructure/deployments/gcp
+
+# An explicit URL takes precedence over Terraform discovery.
+FOUNDRY_URL=https://vtt.example.com scripts/post-deploy-smoke-test.sh
+```
+
+Without an argument, the deployment directory defaults to the current directory.
+`TIMEOUT` controls the curl connection and request timeout in seconds (default
+`10`), and `MAX_LATENCY_MS` sets the response-time budget (default `5000`).
+
+The script validates the URL and hostname, resolves DNS names (while correctly
+skipping DNS for literal IP addresses), requires normal certificate validation
+for HTTPS, and accepts only HTTP 2xx or 3xx responses. DNS, TLS, timeout,
+HTTP 4xx/5xx, and latency failures produce a non-zero exit status.
+
+This is an unauthenticated infrastructure reachability check. It does not log in,
+inspect a Foundry world, or prove that authenticated Foundry workflows succeed.
+
 ## 🔐 Security Best Practices
 
 1. **Secrets Management**

--- a/infrastructure/deployments/gcp/main.tf
+++ b/infrastructure/deployments/gcp/main.tf
@@ -228,6 +228,11 @@ data "google_project" "current" {
 # Outputs
 # =============================================================================
 
+output "foundry_url" {
+  description = "Public LegendForge URL"
+  value       = "https://${var.foundry_hostname}"
+}
+
 output "load_balancer_ip" {
   description = "Load balancer static IP address"
   value       = module.loadbalancer.load_balancer_ip

--- a/infrastructure/deployments/hetzner/outputs.tf
+++ b/infrastructure/deployments/hetzner/outputs.tf
@@ -2,6 +2,11 @@
 # Hetzner Deployment Outputs
 # =============================================================================
 
+output "foundry_url" {
+  description = "Public LegendForge URL"
+  value       = "https://${var.foundry_hostname}"
+}
+
 output "server_public_ipv4" {
   description = "Server public IPv4"
   value       = module.foundry_hetzner.server_public_ipv4

--- a/scripts/post-deploy-smoke-test.sh
+++ b/scripts/post-deploy-smoke-test.sh
@@ -1,0 +1,323 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+# Verify public, unauthenticated reachability after a Terraform deployment.
+#
+# Usage:
+#   scripts/post-deploy-smoke-test.sh [DEPLOYMENT_DIR]
+#   FOUNDRY_URL=https://vtt.example.com scripts/post-deploy-smoke-test.sh
+#
+# FOUNDRY_URL takes precedence over Terraform discovery. Without it, the script
+# reads only `terraform output -raw foundry_url` from DEPLOYMENT_DIR (default: .).
+
+TIMEOUT="${TIMEOUT:-10}"
+MAX_LATENCY_MS="${MAX_LATENCY_MS:-5000}"
+PASS=0
+FAIL=0
+URL=""
+SCHEME=""
+HOST=""
+HOST_IS_IP=0
+
+usage() {
+  printf 'Usage: %s [DEPLOYMENT_DIR]\n' "${0##*/}"
+}
+
+die() {
+  printf 'Error: %s\n' "$1" >&2
+  exit 2
+}
+
+pass() {
+  printf '  [PASS] %s\n' "$1"
+  PASS=$((PASS + 1))
+}
+
+fail() {
+  printf '  [FAIL] %s\n' "$1"
+  FAIL=$((FAIL + 1))
+}
+
+is_positive_decimal() {
+  local value="$1"
+  local nonzero_digits
+
+  [[ "${value}" =~ ^[0-9]+([.][0-9]+)?$ ]] || return 1
+  nonzero_digits="${value//./}"
+  nonzero_digits="${nonzero_digits//0/}"
+  [[ -n "${nonzero_digits}" ]]
+}
+
+validate_port() {
+  local port="$1"
+
+  [[ "${port}" =~ ^[0-9]+$ ]] || return 1
+  [[ "${#port}" -le 5 ]] || return 1
+  ((10#${port} >= 1 && 10#${port} <= 65535))
+}
+
+is_ipv4_literal() {
+  local candidate="$1"
+  local octets=()
+  local octet
+
+  [[ "${candidate}" =~ ^[0-9]+([.][0-9]+){3}$ ]] || return 1
+  IFS='.' read -r -a octets <<<"${candidate}"
+  [[ "${#octets[@]}" -eq 4 ]] || return 1
+  for octet in "${octets[@]}"; do
+    [[ "${#octet}" -le 3 ]] || return 1
+    ((10#${octet} <= 255)) || return 1
+  done
+}
+
+looks_like_ipv4_literal() {
+  [[ "$1" =~ ^[0-9]+([.][0-9]+){3}$ ]]
+}
+
+is_ipv6_literal() {
+  local candidate="$1"
+
+  [[ "${candidate}" == *:* ]] || return 1
+  [[ "${candidate}" =~ ^[0-9A-Fa-f:.]+$ ]]
+}
+
+is_dns_hostname() {
+  local candidate="${1%.}"
+  local labels=()
+  local label
+
+  [[ -n "${candidate}" && "${#candidate}" -le 253 ]] || return 1
+  IFS='.' read -r -a labels <<<"${candidate}"
+  for label in "${labels[@]}"; do
+    [[ -n "${label}" && "${#label}" -le 63 ]] || return 1
+    [[ "${label}" =~ ^[A-Za-z0-9]([A-Za-z0-9-]*[A-Za-z0-9])?$ ]] || return 1
+  done
+}
+
+validate_url() {
+  local authority
+  local port=""
+  local remainder
+  local suffix
+
+  case "${URL}" in
+    http://*)
+      SCHEME="http"
+      remainder="${URL#http://}"
+      ;;
+    https://*)
+      SCHEME="https"
+      remainder="${URL#https://}"
+      ;;
+    *)
+      return 1
+      ;;
+  esac
+
+  [[ -n "${remainder}" ]] || return 1
+  [[ "${remainder}" != *[$' \t\r\n']* ]] || return 1
+  authority="${remainder%%[/?#]*}"
+  [[ -n "${authority}" && "${authority}" != *"@"* ]] || return 1
+
+  if [[ "${authority}" == \[* ]]; then
+    [[ "${authority}" == *"]"* ]] || return 1
+    HOST="${authority#\[}"
+    HOST="${HOST%%\]*}"
+    suffix="${authority#*\]}"
+    [[ -n "${HOST}" ]] || return 1
+    if [[ -n "${suffix}" ]]; then
+      [[ "${suffix}" == :* ]] || return 1
+      port="${suffix#:}"
+      validate_port "${port}" || return 1
+    fi
+    is_ipv6_literal "${HOST}" || return 1
+    HOST_IS_IP=1
+    return 0
+  fi
+
+  [[ "${authority}" != *:*:* ]] || return 1
+  if [[ "${authority}" == *:* ]]; then
+    HOST="${authority%%:*}"
+    port="${authority#*:}"
+    validate_port "${port}" || return 1
+  else
+    HOST="${authority}"
+  fi
+
+  if is_ipv4_literal "${HOST}"; then
+    HOST_IS_IP=1
+    return 0
+  fi
+  looks_like_ipv4_literal "${HOST}" && return 1
+  is_dns_hostname "${HOST}" || return 1
+  HOST_IS_IP=0
+}
+
+resolve_url() {
+  local deployment_dir="${1:-.}"
+  local discovered_url
+
+  if [[ "${FOUNDRY_URL+x}" == "x" ]]; then
+    printf '%s\n' "${FOUNDRY_URL}"
+    return 0
+  fi
+
+  command -v terraform >/dev/null 2>&1 ||
+    die "terraform is required to discover foundry_url; install it or set FOUNDRY_URL."
+
+  if ! discovered_url="$(terraform -chdir="${deployment_dir}" output -raw foundry_url)"; then
+    die "could not read foundry_url from Terraform deployment directory '${deployment_dir}'."
+  fi
+  [[ -n "${discovered_url}" ]] ||
+    die "Terraform output foundry_url is empty in '${deployment_dir}'."
+  printf '%s\n' "${discovered_url}"
+}
+
+check_dns() {
+  local resolver_available=0
+
+  if ((HOST_IS_IP)); then
+    pass "Literal IP ${HOST} does not require DNS resolution"
+    return
+  fi
+
+  if command -v getent >/dev/null 2>&1; then
+    resolver_available=1
+    if getent hosts "${HOST}" >/dev/null 2>&1; then
+      pass "DNS resolves for ${HOST}"
+      return
+    fi
+  fi
+  if command -v host >/dev/null 2>&1; then
+    resolver_available=1
+    if host "${HOST}" >/dev/null 2>&1; then
+      pass "DNS resolves for ${HOST}"
+      return
+    fi
+  fi
+  if command -v nslookup >/dev/null 2>&1; then
+    resolver_available=1
+    if nslookup "${HOST}" >/dev/null 2>&1; then
+      pass "DNS resolves for ${HOST}"
+      return
+    fi
+  fi
+
+  if ((resolver_available)); then
+    fail "DNS does not resolve for ${HOST}"
+  else
+    fail "No supported DNS resolver is available for ${HOST}"
+  fi
+}
+
+latency_to_microseconds() {
+  local value="$1"
+  local seconds
+  local fraction
+
+  [[ "${value}" =~ ^[0-9]+([.][0-9]+)?$ ]] || return 1
+  if [[ "${value}" == *.* ]]; then
+    seconds="${value%%.*}"
+    fraction="${value#*.}"
+  else
+    seconds="${value}"
+    fraction="0"
+  fi
+  [[ "${#seconds}" -le 6 ]] || return 1
+  fraction="${fraction}000000"
+  fraction="${fraction:0:6}"
+  printf '%d\n' "$((10#${seconds} * 1000000 + 10#${fraction}))"
+}
+
+check_http() {
+  local curl_result
+  local curl_status
+  local http_status
+  local latency_s
+  local extra
+  local latency_us
+  local latency_ms
+  local latency_limit_us
+
+  if curl_result="$(
+    curl --silent --show-error \
+      --output /dev/null \
+      --write-out '%{http_code} %{time_total}' \
+      --connect-timeout "${TIMEOUT}" \
+      --max-time "${TIMEOUT}" \
+      "${URL}"
+  )"; then
+    curl_status=0
+  else
+    curl_status=$?
+  fi
+
+  if ((curl_status != 0)); then
+    case "${curl_status}" in
+      28)
+        fail "Request timed out after ${TIMEOUT}s"
+        ;;
+      51 | 60)
+        fail "TLS certificate validation failed"
+        ;;
+      *)
+        fail "Request failed (curl exit ${curl_status})"
+        ;;
+    esac
+    return
+  fi
+
+  read -r http_status latency_s extra <<<"${curl_result}"
+  if [[ -n "${extra:-}" || ! "${http_status}" =~ ^[0-9]{3}$ ]]; then
+    fail "curl returned malformed response metrics"
+    return
+  fi
+
+  if [[ "${http_status}" =~ ^[23][0-9]{2}$ ]]; then
+    pass "Service reachable (HTTP ${http_status})"
+  else
+    fail "Service returned unsuccessful HTTP ${http_status}"
+  fi
+
+  if [[ "${SCHEME}" == "https" ]]; then
+    pass "HTTPS certificate validation passed"
+  fi
+
+  if ! latency_us="$(latency_to_microseconds "${latency_s}")"; then
+    fail "curl returned invalid latency '${latency_s}'"
+    return
+  fi
+  latency_limit_us=$((10#${MAX_LATENCY_MS} * 1000))
+  latency_ms=$(((latency_us + 999) / 1000))
+  if ((latency_us <= latency_limit_us)); then
+    pass "Response latency ${latency_ms}ms is within ${MAX_LATENCY_MS}ms"
+  else
+    fail "Response latency ${latency_ms}ms exceeds ${MAX_LATENCY_MS}ms"
+  fi
+}
+
+if [[ "${1:-}" == "-h" || "${1:-}" == "--help" ]]; then
+  usage
+  exit 0
+fi
+[[ "$#" -le 1 ]] || {
+  usage >&2
+  exit 2
+}
+
+is_positive_decimal "${TIMEOUT}" ||
+  die "TIMEOUT must be a positive number of seconds."
+[[ "${MAX_LATENCY_MS}" =~ ^[0-9]+$ && "${#MAX_LATENCY_MS}" -le 9 ]] ||
+  die "MAX_LATENCY_MS must be a non-negative integer."
+
+URL="$(resolve_url "${1:-.}")"
+validate_url || die "foundry_url must be a valid http:// or https:// URL with a valid hostname."
+command -v curl >/dev/null 2>&1 ||
+  die "curl is required for post-deployment smoke testing."
+
+printf 'Checking post-deployment reachability: %s\n\n' "${URL}"
+check_dns
+check_http
+
+printf '\nSmoke-test results: %d passed, %d failed\n' "${PASS}" "${FAIL}"
+((FAIL == 0))

--- a/tests/test_post_deploy_smoke_test.py
+++ b/tests/test_post_deploy_smoke_test.py
@@ -1,0 +1,275 @@
+from __future__ import annotations
+
+from dataclasses import dataclass
+import os
+from pathlib import Path
+import re
+import subprocess
+import tempfile
+import unittest
+
+
+REPOSITORY_ROOT = Path(__file__).resolve().parents[1]
+SMOKE_SCRIPT = REPOSITORY_ROOT / "scripts" / "post-deploy-smoke-test.sh"
+PROVIDER_OUTPUT_FILES = {
+    "aws": REPOSITORY_ROOT / "infrastructure" / "deployments" / "aws" / "main.tf",
+    "azure": REPOSITORY_ROOT
+    / "infrastructure"
+    / "deployments"
+    / "azure"
+    / "outputs.tf",
+    "gcp": REPOSITORY_ROOT / "infrastructure" / "deployments" / "gcp" / "main.tf",
+    "hetzner": REPOSITORY_ROOT
+    / "infrastructure"
+    / "deployments"
+    / "hetzner"
+    / "outputs.tf",
+}
+
+
+@dataclass
+class SmokeRun:
+    result: subprocess.CompletedProcess[str]
+    curl_calls: list[str]
+    dns_calls: list[str]
+    terraform_calls: list[str]
+
+
+class PostDeploySmokeTestTests(unittest.TestCase):
+    def write_executable(self, path: Path, body: str) -> None:
+        path.write_text(body, encoding="utf-8")
+        path.chmod(0o755)
+
+    def run_smoke(
+        self,
+        *,
+        url: str | None = "https://foundry.example.com",
+        arguments: tuple[object, ...] = (),
+        status: str = "204",
+        latency: str = "0.050000",
+        curl_mode: str = "success",
+        dns_result: str = "success",
+        timeout: str = "10",
+        max_latency_ms: str = "5000",
+        terraform_url: str = "https://terraform.example.com",
+        include_terraform: bool = True,
+    ) -> SmokeRun:
+        with tempfile.TemporaryDirectory() as temporary:
+            workspace = Path(temporary)
+            fake_bin = workspace / "bin"
+            fake_bin.mkdir()
+            curl_log = workspace / "curl.log"
+            dns_log = workspace / "dns.log"
+            terraform_log = workspace / "terraform.log"
+
+            self.write_executable(
+                fake_bin / "curl",
+                """#!/bin/bash
+printf '%s\n' "$*" >>"${FAKE_CURL_LOG}"
+case "${FAKE_CURL_MODE}" in
+  success)
+    printf '%s %s' "${FAKE_HTTP_STATUS}" "${FAKE_LATENCY}"
+    ;;
+  timeout)
+    exit 28
+    ;;
+  tls)
+    exit 60
+    ;;
+  network)
+    exit 7
+    ;;
+  *)
+    exit 64
+    ;;
+esac
+""",
+            )
+            self.write_executable(
+                fake_bin / "getent",
+                """#!/bin/bash
+printf '%s\n' "$*" >>"${FAKE_DNS_LOG}"
+[[ "${FAKE_DNS_RESULT}" == "success" ]]
+""",
+            )
+            if include_terraform:
+                self.write_executable(
+                    fake_bin / "terraform",
+                    """#!/bin/bash
+printf '%s\n' "$*" >>"${FAKE_TERRAFORM_LOG}"
+printf '%s' "${FAKE_TERRAFORM_URL}"
+""",
+                )
+
+            environment = {
+                **os.environ,
+                "PATH": str(fake_bin),
+                "FAKE_CURL_LOG": str(curl_log),
+                "FAKE_DNS_LOG": str(dns_log),
+                "FAKE_TERRAFORM_LOG": str(terraform_log),
+                "FAKE_CURL_MODE": curl_mode,
+                "FAKE_HTTP_STATUS": status,
+                "FAKE_LATENCY": latency,
+                "FAKE_DNS_RESULT": dns_result,
+                "FAKE_TERRAFORM_URL": terraform_url,
+                "TIMEOUT": timeout,
+                "MAX_LATENCY_MS": max_latency_ms,
+            }
+            if url is None:
+                environment.pop("FOUNDRY_URL", None)
+            else:
+                environment["FOUNDRY_URL"] = url
+
+            result = subprocess.run(
+                ["/bin/bash", str(SMOKE_SCRIPT), *(str(arg) for arg in arguments)],
+                check=False,
+                capture_output=True,
+                env=environment,
+                text=True,
+            )
+
+            def read_calls(log: Path) -> list[str]:
+                return log.read_text(encoding="utf-8").splitlines() if log.exists() else []
+
+            return SmokeRun(
+                result=result,
+                curl_calls=read_calls(curl_log),
+                dns_calls=read_calls(dns_log),
+                terraform_calls=read_calls(terraform_log),
+            )
+
+    def test_foundry_url_environment_takes_precedence_over_terraform(self) -> None:
+        run = self.run_smoke(
+            url="https://override.example.com",
+            arguments=("/deployment/that/does/not/exist",),
+        )
+
+        self.assertEqual(0, run.result.returncode, run.result.stderr)
+        self.assertIn("https://override.example.com", run.result.stdout)
+        self.assertEqual([], run.terraform_calls)
+
+    def test_each_provider_directory_uses_only_foundry_url_output(self) -> None:
+        for provider in PROVIDER_OUTPUT_FILES:
+            with self.subTest(provider=provider):
+                deployment_dir = (
+                    REPOSITORY_ROOT / "infrastructure" / "deployments" / provider
+                )
+                run = self.run_smoke(url=None, arguments=(deployment_dir,))
+
+                self.assertEqual(0, run.result.returncode, run.result.stderr)
+                self.assertEqual(
+                    [f"-chdir={deployment_dir} output -raw foundry_url"],
+                    run.terraform_calls,
+                )
+
+    def test_all_provider_deployments_have_non_sensitive_foundry_url_output(
+        self,
+    ) -> None:
+        for provider, output_file in PROVIDER_OUTPUT_FILES.items():
+            with self.subTest(provider=provider):
+                contents = output_file.read_text(encoding="utf-8")
+                match = re.search(
+                    r'^output "foundry_url" \{\n.*?^\}',
+                    contents,
+                    flags=re.MULTILINE | re.DOTALL,
+                )
+                self.assertIsNotNone(match, f"{provider} lacks foundry_url")
+                output_block = match.group(0)
+                self.assertNotRegex(output_block, r"(?m)^\s*sensitive\s*=\s*true")
+                self.assertRegex(
+                    output_block,
+                    r'(?m)^\s*value\s*=\s*"https?://',
+                )
+
+    def test_dns_hostname_is_resolved(self) -> None:
+        run = self.run_smoke(url="https://foundry.example.com")
+
+        self.assertEqual(0, run.result.returncode, run.result.stderr)
+        self.assertEqual(["hosts foundry.example.com"], run.dns_calls)
+
+    def test_dns_failure_fails_the_smoke_test(self) -> None:
+        run = self.run_smoke(dns_result="failure")
+
+        self.assertNotEqual(0, run.result.returncode)
+        self.assertIn("DNS does not resolve", run.result.stdout)
+
+    def test_literal_ip_addresses_skip_dns(self) -> None:
+        for url in ("http://192.0.2.10:30000", "https://[2001:db8::10]:443"):
+            with self.subTest(url=url):
+                run = self.run_smoke(url=url)
+
+                self.assertEqual(0, run.result.returncode, run.result.stderr)
+                self.assertEqual([], run.dns_calls)
+                self.assertIn("does not require DNS", run.result.stdout)
+
+    def test_only_2xx_and_3xx_status_classes_succeed(self) -> None:
+        for status in ("200", "204", "301", "399"):
+            with self.subTest(status=status):
+                run = self.run_smoke(status=status)
+                self.assertEqual(0, run.result.returncode, run.result.stdout)
+
+        for status in ("199", "400", "401", "403", "500", "503"):
+            with self.subTest(status=status):
+                run = self.run_smoke(status=status)
+                self.assertNotEqual(0, run.result.returncode)
+                self.assertIn(f"unsuccessful HTTP {status}", run.result.stdout)
+
+    def test_timeout_is_reported_as_failure(self) -> None:
+        run = self.run_smoke(curl_mode="timeout", timeout="7")
+
+        self.assertNotEqual(0, run.result.returncode)
+        self.assertIn("timed out after 7s", run.result.stdout)
+        self.assertIn("--connect-timeout 7 --max-time 7", run.curl_calls[0])
+
+    def test_tls_certificate_failure_is_reported(self) -> None:
+        run = self.run_smoke(curl_mode="tls")
+
+        self.assertNotEqual(0, run.result.returncode)
+        self.assertIn("TLS certificate validation failed", run.result.stdout)
+
+    def test_https_uses_normal_certificate_validation(self) -> None:
+        run = self.run_smoke()
+
+        self.assertEqual(0, run.result.returncode, run.result.stderr)
+        curl_arguments = run.curl_calls[0].split()
+        self.assertNotIn("-k", curl_arguments)
+        self.assertNotIn("--insecure", curl_arguments)
+        self.assertIn("HTTPS certificate validation passed", run.result.stdout)
+
+    def test_latency_threshold_and_boundary(self) -> None:
+        at_limit = self.run_smoke(latency="0.500000", max_latency_ms="500")
+        over_limit = self.run_smoke(latency="0.500001", max_latency_ms="500")
+
+        self.assertEqual(0, at_limit.result.returncode, at_limit.result.stdout)
+        self.assertNotEqual(0, over_limit.result.returncode)
+        self.assertIn("exceeds 500ms", over_limit.result.stdout)
+
+    def test_invalid_urls_and_hostnames_are_rejected_before_curl(self) -> None:
+        invalid_urls = (
+            "",
+            "ftp://foundry.example.com",
+            "https://",
+            "https://bad_host.example.com",
+            "https://-bad.example.com",
+            "https://999.0.0.1",
+            "https://2001:db8::1",
+        )
+        for url in invalid_urls:
+            with self.subTest(url=url):
+                run = self.run_smoke(url=url)
+
+                self.assertEqual(2, run.result.returncode)
+                self.assertEqual([], run.curl_calls)
+                self.assertIn("valid http:// or https://", run.result.stderr)
+
+    def test_smoke_test_does_not_probe_setup_or_other_paths(self) -> None:
+        run = self.run_smoke(url="https://foundry.example.com/custom")
+
+        self.assertEqual(0, run.result.returncode, run.result.stderr)
+        self.assertEqual(1, len(run.curl_calls))
+        self.assertTrue(run.curl_calls[0].endswith("https://foundry.example.com/custom"))
+        self.assertNotIn("/setup", SMOKE_SCRIPT.read_text(encoding="utf-8"))
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
Closes #69.

## Summary
- add non-sensitive `foundry_url` outputs to the active GCP and Hetzner deployments, matching AWS/Azure
- add `scripts/post-deploy-smoke-test.sh [DEPLOYMENT_DIR]` with `FOUNDRY_URL` precedence and Terraform-only fallback
- validate URLs/hosts, skip DNS for literal IPs, enforce HTTPS certificate validity, accept only 2xx/3xx, and enforce timeout/latency limits
- document provider-neutral usage and replace the issue-specific acceptance-test hook name
- add 13 deterministic smoke-test cases plus all-provider output coverage

## Exact-head validation
- `python3 -m unittest discover -s tests -p 'test_*.py'` — 40 passed
- `bash -n scripts/post-deploy-smoke-test.sh` — passed
- `shellcheck scripts/post-deploy-smoke-test.sh` (ShellCheck 0.11.0) — passed
- `TERRAFORM_QUALITY_TARGETS=aws,azure,gcp,hetzner scripts/terraform-quality.sh` — passed for all four providers
- `pre-commit run --all-files` — passed
- pre-push Semgrep — 0 findings
- pre-push TruffleHog — 0 verified or unverified secrets; gate passed
- `git diff --check origin/main...HEAD` — passed

The legacy `copilot/improve-unit-testing-post-deployment` commit was audited but not reused: it lacks provider outputs/tests and has weaker HTTP, timeout, TLS, and DNS behavior.