### PR TITLE
fix(terraform): remove provider deprecation warnings

### DIFF
--- a/infrastructure/modules/aws-cloudwatch/data.tf
+++ b/infrastructure/modules/aws-cloudwatch/data.tf
@@ -1,1 +1,0 @@
-data "aws_region" "current" {}

--- a/infrastructure/modules/aws-cloudwatch/outputs.tf
+++ b/infrastructure/modules/aws-cloudwatch/outputs.tf
@@ -15,5 +15,5 @@ output "rds_log_group" {
 
 output "dashboard_url" {
   description = "CloudWatch dashboard URL"
-  value       = "https://console.aws.amazon.com/cloudwatch/home?region=${data.aws_region.current.name}#dashboards:name=${aws_cloudwatch_dashboard.foundry.dashboard_name}"
+  value       = "https://console.aws.amazon.com/cloudwatch/home?region=${var.aws_region}#dashboards:name=${aws_cloudwatch_dashboard.foundry.dashboard_name}"
 }

--- a/infrastructure/modules/gcp-vpc/main.tf
+++ b/infrastructure/modules/gcp-vpc/main.tf
@@ -160,9 +160,11 @@ resource "google_compute_firewall" "deny_all_ingress" {
     protocol = "all"
   }
 
-  direction      = "INGRESS"
-  priority       = 65534
-  source_ranges  = ["0.0.0.0/0"]
-  target_tags    = []
-  enable_logging = true
+  direction     = "INGRESS"
+  priority      = 65534
+  source_ranges = ["0.0.0.0/0"]
+  target_tags   = []
+  log_config {
+    metadata = "INCLUDE_ALL_METADATA"
+  }
 }


### PR DESCRIPTION
## Summary
- use the AWS CloudWatch module region input in the dashboard URL and remove its unused region data source
- replace the deprecated GCP firewall enable_logging attribute with an explicit log_config that includes metadata

## Validation
- TERRAFORM_QUALITY_TARGETS=aws,gcp scripts/terraform-quality.sh
- TERRAFORM_QUALITY_TARGETS=aws,azure,gcp,hetzner scripts/terraform-quality.sh
- pre-commit run --all-files
- push gates: Semgrep 0 findings; TruffleHog 0 secrets

No cloud plan or apply was run: this is a provider-schema deprecation cleanup, while state-backed infrastructure changes remain outside this PR.