### PR TITLE
docs: clarify milestone secret scanning guidance

### DIFF
--- a/.agents/skills/milestone-delivery/SKILL.md
+++ b/.agents/skills/milestone-delivery/SKILL.md
@@ -119,12 +119,15 @@ create an issue only when authorized and called for by the project or user.
 
 Before committing or posting, inspect the exact outgoing files, commit range,
 and text. Stage only intended paths. Run the repository's documented secret and
-private-artifact checks where available. If none exist, use an available trusted
-secret scanner on the staged content and outgoing commit range, with sensitive
-values redacted. Record the command, coverage, and result; dependency or source
-vulnerability checks do not substitute for secret scanning. If a suitable scanner
-cannot run, report the missing check as a publication blocker and continue safe
-local work. Do not bypass required checks or claim unperformed scanning passed.
+private-artifact checks where available. If the repository has no documented
+secret-scanning check, use an available trusted secret scanner regardless of
+whether private-artifact checks exist. Scan the original staged content and
+outgoing commit range; redact only scanner diagnostics and recorded output,
+never the input before detection. Record the command, coverage, and result;
+dependency or source vulnerability checks do not substitute for secret scanning.
+If a suitable scanner cannot run, report the missing check as a publication
+blocker and continue safe local work. Do not bypass required checks or claim
+unperformed scanning passed.
 
 Do not publish credentials, personal or customer records, private URLs or machine
 paths, runtime prompt/response payloads, logs, or unsanitized reports. Store only

--- a/prompts/README.md
+++ b/prompts/README.md
@@ -118,5 +118,11 @@ Commit reusable instructions and synthetic placeholders only. Keep completed
 run prompts, credentials, personal data, local paths, logs, workboard databases,
 and unsanitized run reports out of Git. Store runtime checkpoints in the host's
 approved private or untracked location. Review exact diffs and outgoing commits
-with the project's secret checks before publishing. Public issue summaries and
-final reports must contain only information suitable for their audience.
+before publishing. Run the project's secret-scanning and private-artifact checks
+where available. If no documented secret scanner exists, use a trusted scanner
+on the original staged content and outgoing commit range, even when a separate
+private-artifact check exists. Redact only diagnostics and recorded output, not
+scan input. If a suitable scanner cannot run, publication is blocked; continue
+safe local work and report the missing check. See the skill's privacy procedure
+for full requirements. Public issue summaries and final reports must contain
+only information suitable for their audience.


### PR DESCRIPTION
The milestone workflow's scanner fallback was ambiguous when a repository had private-artifact checks but no secret scanner, and its redaction wording could be read as redacting input before detection. Require secret scanning independently, scan original staged content and outgoing commits, and redact diagnostics and recorded output only. Make the usage guide state the fallback and publication blocker directly.

These clarifications address the supported review findings in [AncestryLLM #483](https://github.com/sodejm/AncestryLLM/pull/483) and keep the shared workflow consistent. Application architecture, runtime behavior, dependencies, and deployment are unaffected; the change improves workflow privacy instructions.

Validation: repository checks passed; exact diff review and whitespace checks passed; Gitleaks found no leaks in the staged diff and outgoing commit range. The commit was signed and locally verified. Hosted checks and review will be verified before merge.
