### PR TITLE
fix: guard resumed milestone publication and isolate subagent commits

### DIFF
--- a/.agents/skills/milestone-delivery/SKILL.md
+++ b/.agents/skills/milestone-delivery/SKILL.md
@@ -43,8 +43,11 @@ Before each launch:
 
 1. Define the deliverable, allowed paths and mutations, prohibited actions,
    dependencies, acceptance checks, and required evidence in the task contract.
-   Assign distinct write ownership or isolated worktrees to avoid conflicting
-   edits. Subagents return results to the orchestrator; reserve pushes, merges,
+   Assign distinct path ownership to avoid conflicting edits. Concurrent agents
+   that stage or commit must use separate worktrees with separate Git indexes.
+   In a shared checkout, reserve all staging and commits for the orchestrator;
+   disjoint paths alone do not isolate the Git index. Subagents return results
+   to the orchestrator; reserve pushes, merges,
    issue updates, releases, and deployment for the orchestrator unless the task
    contract explicitly delegates an already-authorized action.
 2. Apply the available `subagent-model-router` and its required coordination
@@ -117,8 +120,14 @@ policy for timing and state transitions. Keep updates concise and avoid duplicat
 status noise. If no issue applies, use an authorized PR update or the final report;
 create an issue only when authorized and called for by the project or user.
 
-Before committing or posting, inspect the exact outgoing files, commit range,
-and text. Stage only intended paths. Run the repository's documented secret and
+Before committing, inspect and scan the intended staged content. Immediately
+before every push, PR or release publication, deployment, or public comment,
+inspect and scan the exact content being sent: outgoing commits, files, artifacts,
+and text as applicable. This gate also applies to resumed runs and existing local
+commits when no new commit is created. Recheck changed content before sending it;
+previous scans do not cover later changes. Stage only intended paths.
+
+Run the repository's documented secret and
 private-artifact checks where available. If the repository has no documented
 secret-scanning check, use an available trusted secret scanner regardless of
 whether private-artifact checks exist. Scan the original staged content and

--- a/prompts/README.md
+++ b/prompts/README.md
@@ -117,8 +117,11 @@ adapter should point to or be generated from the canonical skill.
 Commit reusable instructions and synthetic placeholders only. Keep completed
 run prompts, credentials, personal data, local paths, logs, workboard databases,
 and unsanitized run reports out of Git. Store runtime checkpoints in the host's
-approved private or untracked location. Review exact diffs and outgoing commits
-before publishing. Run the project's secret-scanning and private-artifact checks
+approved private or untracked location. Inspect and scan staged content before
+committing, and the exact outgoing content immediately before every push, PR or
+release publication, deployment, or public comment. This includes resumed runs
+that publish existing commits without creating a new commit. Recheck any changed
+content before sending it. Run the project's secret-scanning and private-artifact checks
 where available. If no documented secret scanner exists, use a trusted scanner
 on the original staged content and outgoing commit range, even when a separate
 private-artifact check exists. Redact only diagnostics and recorded output, not


### PR DESCRIPTION
Resumed milestone runs could publish existing commits without a fresh secret scan, and concurrent subagents could share a Git index while committing. The milestone workflow now scans exact outgoing content immediately before every publication, including resumed runs, and requires separate worktrees/indexes for subagents that stage or commit. In a shared checkout, the orchestrator owns all staging and commits.

The usage guide matches these rules. The prompt remains portable and the main goal agent retains integration ownership.

Validation: `pre-commit run --files .agents/skills/milestone-delivery/SKILL.md prompts/README.md` passed all applicable hooks, including 76 repository acceptance tests and TruffleHog. Exact staged-content and outgoing-commit Gitleaks scans passed with redacted diagnostics, and the complete patch was inspected for private data. Commits are signed. This documentation change has no application behavior requiring a failing behavior test.

Architecture and threat-model impact: application boundaries and data handling are unchanged; this tightens the agent workflow. No dependencies, runtime configuration, release artifacts, or provenance paths change. Existing prompt/skill documentation is the affected surface; API, operational, and product release documentation need no changes. Rollback is a documentation revert.
